### PR TITLE
scanner: use an infinitive verb after the auxiliary word could

### DIFF
--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -286,7 +286,7 @@ class Scanner(object):
                     or self.index-key.index > 1024:
                 if key.required:
                     raise ScannerError("while scanning a simple key", key.mark,
-                            "could not found expected ':'", self.get_mark())
+                            "could not find expected ':'", self.get_mark())
                 del self.possible_simple_keys[level]
 
     def save_possible_simple_key(self):
@@ -317,7 +317,7 @@ class Scanner(object):
             
             if key.required:
                 raise ScannerError("while scanning a simple key", key.mark,
-                        "could not found expected ':'", self.get_mark())
+                        "could not find expected ':'", self.get_mark())
 
             del self.possible_simple_keys[self.flow_level]
 

--- a/lib3/yaml/scanner.py
+++ b/lib3/yaml/scanner.py
@@ -286,7 +286,7 @@ class Scanner:
                     or self.index-key.index > 1024:
                 if key.required:
                     raise ScannerError("while scanning a simple key", key.mark,
-                            "could not found expected ':'", self.get_mark())
+                            "could not find expected ':'", self.get_mark())
                 del self.possible_simple_keys[level]
 
     def save_possible_simple_key(self):
@@ -317,7 +317,7 @@ class Scanner:
             
             if key.required:
                 raise ScannerError("while scanning a simple key", key.mark,
-                        "could not found expected ':'", self.get_mark())
+                        "could not find expected ':'", self.get_mark())
 
             del self.possible_simple_keys[self.flow_level]
 


### PR DESCRIPTION
Could, as well as should, shall, must, may, can, might, etc. are auxiliary words. After an auxiliary word should come an infinitive verb.