### PR TITLE
Extract a method to represent keys in mappings, so that a subclass ca…

### DIFF
--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -71,6 +71,9 @@ class BaseRepresenter(object):
         #    self.represented_objects[alias_key] = node
         return node
 
+    def represent_key(self, item_key):
+        return self.represent_data(item_key)
+
     def add_representer(cls, data_type, representer):
         if not 'yaml_representers' in cls.__dict__:
             cls.yaml_representers = cls.yaml_representers.copy()
@@ -119,7 +122,7 @@ class BaseRepresenter(object):
             mapping = mapping.items()
             mapping.sort()
         for item_key, item_value in mapping:
-            node_key = self.represent_data(item_key)
+            node_key = self.represent_key(item_key)
             node_value = self.represent_data(item_value)
             if not (isinstance(node_key, ScalarNode) and not node_key.style):
                 best_style = False

--- a/lib3/yaml/representer.py
+++ b/lib3/yaml/representer.py
@@ -61,6 +61,9 @@ class BaseRepresenter:
         #    self.represented_objects[alias_key] = node
         return node
 
+    def represent_key(self, item_key):
+        return self.represent_data(item_key)
+
     @classmethod
     def add_representer(cls, data_type, representer):
         if not 'yaml_representers' in cls.__dict__:
@@ -112,7 +115,7 @@ class BaseRepresenter:
             except TypeError:
                 pass
         for item_key, item_value in mapping:
-            node_key = self.represent_data(item_key)
+            node_key = self.represent_key(item_key)
             node_value = self.represent_data(item_value)
             if not (isinstance(node_key, ScalarNode) and not node_key.style):
                 best_style = False


### PR DESCRIPTION
We wanted to extend `pyyaml` so that we could make keys unquoted in our representation of config files. However, there's no easy way to do this without copying the whole `represent_mapping` method. This simple refactor makes it trivial to do in a subclass, without breaking any tests
