### PR TITLE
Fix a bug attempting to write str to a unicode-only stream

### DIFF
--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -1071,7 +1071,7 @@ class Emitter(object):
                     data = text[start:end]
                     if self.encoding:
                         data = data.encode(self.encoding)
-                    self.stream.write(data)
+                    self.stream.write(unicode(data))
                     if ch is None:
                         self.write_line_break()
                     start = end


### PR DESCRIPTION
The PyYAML tried to write str type to a unicode only stream and raised error for me. This patch fixed the one that actually caused the trouble but there might be other places with the same issue.

Question: should we cast all of the data before write them to a stream?