### PR TITLE
Install tox in a virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ install:
     - ./.travis/install.sh
 
 script:
+  - source ~/.venv/bin/activate
   - tox

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,10 +8,10 @@ if [[ "${TOXENV}" = pypy* ]]; then
     pyenv install "pypy-$PYPY_VERSION"
     pyenv global "pypy-$PYPY_VERSION"
 
-    pip install --upgrade tox
-
     pyenv rehash
 fi
 
-
+pip install --upgrade virtualenv
+virtualenv ~/.venv
+source ~/.venv/bin/activate
 pip install --upgrade tox


### PR DESCRIPTION
Since TravisCI has an extremely old version of PyPy, we need to use
pyenv to install a more recent version. However, pyenv's shims don't
persist between the install and script portions of Travis. So we have to
use a virtualenv so Travis can find the tox command.