### PR TITLE
Improve RepresenterError creation

### DIFF
--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -246,7 +246,7 @@ class SafeRepresenter(BaseRepresenter):
         return self.represent_mapping(tag, state, flow_style=flow_style)
 
     def represent_undefined(self, data):
-        raise RepresenterError("cannot represent an object: %s" % data)
+        raise RepresenterError("cannot represent an object", data)
 
 SafeRepresenter.add_representer(type(None),
         SafeRepresenter.represent_none)
@@ -411,7 +411,7 @@ class Representer(SafeRepresenter):
         elif hasattr(data, '__reduce__'):
             reduce = data.__reduce__()
         else:
-            raise RepresenterError("cannot represent object: %r" % data)
+            raise RepresenterError("cannot represent an object", data)
         reduce = (list(reduce)+[None]*5)[:5]
         function, args, state, listitems, dictitems = reduce
         args = list(args)

--- a/lib3/yaml/representer.py
+++ b/lib3/yaml/representer.py
@@ -226,7 +226,7 @@ class SafeRepresenter(BaseRepresenter):
         return self.represent_mapping(tag, state, flow_style=flow_style)
 
     def represent_undefined(self, data):
-        raise RepresenterError("cannot represent an object: %s" % data)
+        raise RepresenterError("cannot represent an object", data)
 
 SafeRepresenter.add_representer(type(None),
         SafeRepresenter.represent_none)
@@ -316,7 +316,7 @@ class Representer(SafeRepresenter):
         elif hasattr(data, '__reduce__'):
             reduce = data.__reduce__()
         else:
-            raise RepresenterError("cannot represent object: %r" % data)
+            raise RepresenterError("cannot represent an object", data)
         reduce = (list(reduce)+[None]*5)[:5]
         function, args, state, listitems, dictitems = reduce
         args = list(args)


### PR DESCRIPTION
Passing data as an parameter for RepresenterError allows user to make some research about nature of a failed object.

**Before:**
```python
>>> import yaml
>>> import numpy as np
>>> lst = list(map(np.int16, range(5, 10)))
>>> lst
[5, 6, 7, 8, 9]
>>> try:
...     yaml.dump(lst, Dumper=yaml.SafeDumper)
... except yaml.representer.RepresenterError as e:
...     print(e)
cannot represent an object: 5
```
Nothing we can do to understand why 5 can't be represented.

**After:**
```python
>>> try:
...     yaml.dump(lst, Dumper=yaml.SafeDumper)
... except yaml.representer.RepresenterError as e:
...     print(e)
...     if len(e.args) > 1:
...         bad_object = e.args[1]
...         print("Can't represent an object %r of type %s" % (bad_object, type(bad_object)))
...
('cannot represent an object', 5)
Can't represent an object 5 of type <class 'numpy.int16'>
```

It's even better to have an Exception class with explicit argument for bad object, but I decided to start with smaller changes.