### PR TITLE
Make pyyaml safe by default.

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -65,17 +65,24 @@ def load(stream, Loader=Loader):
     """
     Parse the first YAML document in a stream
     and produce the corresponding Python object.
+
+    By default resolve only basic YAML tags, if an alternate Loader is
+    provided, may be dangerous.
     """
     loader = Loader(stream)
     try:
         return loader.get_single_data()
     finally:
         loader.dispose()
+safe_load = load
 
 def load_all(stream, Loader=Loader):
     """
     Parse all YAML documents in a stream
     and produce corresponding Python objects.
+
+    By default resolve only basic YAML tags, if an alternate Loader is
+    provided, may be dangerous.
     """
     loader = Loader(stream)
     try:
@@ -83,22 +90,23 @@ def load_all(stream, Loader=Loader):
             yield loader.get_data()
     finally:
         loader.dispose()
+safe_load_all = load_all
 
-def safe_load(stream):
+def danger_load(stream):
     """
     Parse the first YAML document in a stream
     and produce the corresponding Python object.
-    Resolve only basic YAML tags.
+    When used on untrusted input, can result in arbitrary code execution.
     """
-    return load(stream, SafeLoader)
+    return load(stream, DangerLoader)
 
-def safe_load_all(stream):
+def danger_load_all(stream):
     """
     Parse all YAML documents in a stream
     and produce corresponding Python objects.
-    Resolve only basic YAML tags.
+    When used on untrusted input, can result in arbitrary code execution.
     """
-    return load_all(stream, SafeLoader)
+    return load_all(stream, DangerLoader)
 
 def emit(events, stream=None, Dumper=Dumper,
         canonical=None, indent=None, width=None,
@@ -193,6 +201,15 @@ def dump_all(documents, stream=None, Dumper=Dumper,
         dumper.dispose()
     if getvalue:
         return getvalue()
+safe_dump_all = dump_all
+
+def danger_dump_all(documents, stream=None, **kwds):
+    """
+    Serialize a sequence of Python objects into a YAML stream.
+    Produce only basic YAML tags.
+    If stream is None, return the produced string instead.
+    """
+    return dump_all(documents, stream, Dumper=DangerDumper, **kwds)
 
 def dump(data, stream=None, Dumper=Dumper, **kwds):
     """
@@ -200,22 +217,15 @@ def dump(data, stream=None, Dumper=Dumper, **kwds):
     If stream is None, return the produced string instead.
     """
     return dump_all([data], stream, Dumper=Dumper, **kwds)
+safe_dump = dump
 
-def safe_dump_all(documents, stream=None, **kwds):
-    """
-    Serialize a sequence of Python objects into a YAML stream.
-    Produce only basic YAML tags.
-    If stream is None, return the produced string instead.
-    """
-    return dump_all(documents, stream, Dumper=SafeDumper, **kwds)
-
-def safe_dump(data, stream=None, **kwds):
+def danger_dump(data, stream=None, **kwds):
     """
     Serialize a Python object into a YAML stream.
     Produce only basic YAML tags.
     If stream is None, return the produced string instead.
     """
-    return dump_all([data], stream, Dumper=SafeDumper, **kwds)
+    return dump_all([data], stream, Dumper=DangerDumper, **kwds)
 
 def add_implicit_resolver(tag, regexp, first=None,
         Loader=Loader, Dumper=Dumper):
@@ -312,4 +322,3 @@ class YAMLObject(object):
         return dumper.represent_yaml_object(cls.yaml_tag, data, cls,
                 flow_style=cls.yaml_flow_style)
     to_yaml = classmethod(to_yaml)
-

--- a/lib/yaml/cyaml.py
+++ b/lib/yaml/cyaml.py
@@ -1,6 +1,6 @@
 
-__all__ = ['CBaseLoader', 'CSafeLoader', 'CLoader',
-        'CBaseDumper', 'CSafeDumper', 'CDumper']
+__all__ = ['CBaseLoader', 'CSafeLoader', 'CLoader', 'CDangerLoader',
+        'CBaseDumper', 'CSafeDumper', 'CDumper', 'CDangerDumper']
 
 from _yaml import CParser, CEmitter
 
@@ -18,14 +18,15 @@ class CBaseLoader(CParser, BaseConstructor, BaseResolver):
         BaseConstructor.__init__(self)
         BaseResolver.__init__(self)
 
-class CSafeLoader(CParser, SafeConstructor, Resolver):
+class CLoader(CParser, SafeConstructor, Resolver):
 
     def __init__(self, stream):
         CParser.__init__(self, stream)
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
+CSafeLoader = CLoader
 
-class CLoader(CParser, Constructor, Resolver):
+class CDangerLoader(CParser, Constructor, Resolver):
 
     def __init__(self, stream):
         CParser.__init__(self, stream)
@@ -49,7 +50,7 @@ class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
 
-class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
+class CDumper(CEmitter, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -65,8 +66,9 @@ class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
         SafeRepresenter.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
+CSafeDumper = CDumper
 
-class CDumper(CEmitter, Serializer, Representer, Resolver):
+class CDangerDumper(CEmitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -82,4 +84,3 @@ class CDumper(CEmitter, Serializer, Representer, Resolver):
         Representer.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
-

--- a/lib/yaml/dumper.py
+++ b/lib/yaml/dumper.py
@@ -1,5 +1,5 @@
 
-__all__ = ['BaseDumper', 'SafeDumper', 'Dumper']
+__all__ = ['BaseDumper', 'SafeDumper', 'Dumper', 'DangerDumper']
 
 from emitter import *
 from serializer import *
@@ -24,7 +24,7 @@ class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
 
-class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
+class Dumper(Emitter, Serializer, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -41,8 +41,9 @@ class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
         SafeRepresenter.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
+SafeDumper = Dump
 
-class Dumper(Emitter, Serializer, Representer, Resolver):
+class DangerDumper(Emitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -59,4 +60,3 @@ class Dumper(Emitter, Serializer, Representer, Resolver):
         Representer.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
-

--- a/lib/yaml/dumper.py
+++ b/lib/yaml/dumper.py
@@ -41,7 +41,7 @@ class Dumper(Emitter, Serializer, SafeRepresenter, Resolver):
         SafeRepresenter.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
-SafeDumper = Dump
+SafeDumper = Dumper
 
 class DangerDumper(Emitter, Serializer, Representer, Resolver):
 

--- a/lib/yaml/loader.py
+++ b/lib/yaml/loader.py
@@ -1,5 +1,5 @@
 
-__all__ = ['BaseLoader', 'SafeLoader', 'Loader']
+__all__ = ['BaseLoader', 'SafeLoader', 'Loader', 'DangerLoader']
 
 from reader import *
 from scanner import *
@@ -18,7 +18,7 @@ class BaseLoader(Reader, Scanner, Parser, Composer, BaseConstructor, BaseResolve
         BaseConstructor.__init__(self)
         BaseResolver.__init__(self)
 
-class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
+class Loader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
 
     def __init__(self, stream):
         Reader.__init__(self, stream)
@@ -27,8 +27,9 @@ class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
         Composer.__init__(self)
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
+SafeLoader = Loader
 
-class Loader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
+class DangerLoader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
 
     def __init__(self, stream):
         Reader.__init__(self, stream)
@@ -37,4 +38,3 @@ class Loader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
         Composer.__init__(self)
         Constructor.__init__(self)
         Resolver.__init__(self)
-

--- a/lib3/yaml/__init__.py
+++ b/lib3/yaml/__init__.py
@@ -66,17 +66,24 @@ def load(stream, Loader=Loader):
     """
     Parse the first YAML document in a stream
     and produce the corresponding Python object.
+
+    By default resolve only basic YAML tags, if an alternate Loader is
+    provided, may be dangerous.
     """
     loader = Loader(stream)
     try:
         return loader.get_single_data()
     finally:
         loader.dispose()
+safe_load = load
 
 def load_all(stream, Loader=Loader):
     """
     Parse all YAML documents in a stream
     and produce corresponding Python objects.
+
+    By default resolve only basic YAML tags, if an alternate Loader is
+    provided, may be dangerous.
     """
     loader = Loader(stream)
     try:
@@ -84,22 +91,23 @@ def load_all(stream, Loader=Loader):
             yield loader.get_data()
     finally:
         loader.dispose()
+safe_load_all = load_all
 
-def safe_load(stream):
+def danger_load(stream):
     """
     Parse the first YAML document in a stream
     and produce the corresponding Python object.
-    Resolve only basic YAML tags.
+    When used on untrusted input, can result in arbitrary code execution.
     """
-    return load(stream, SafeLoader)
+    return load(stream, DangerLoader)
 
-def safe_load_all(stream):
+def danger_load_all(stream):
     """
     Parse all YAML documents in a stream
     and produce corresponding Python objects.
-    Resolve only basic YAML tags.
+    When used on untrusted input, can result in arbitrary code execution.
     """
-    return load_all(stream, SafeLoader)
+    return load_all(stream, DangerLoader)
 
 def emit(events, stream=None, Dumper=Dumper,
         canonical=None, indent=None, width=None,
@@ -191,6 +199,15 @@ def dump_all(documents, stream=None, Dumper=Dumper,
         dumper.dispose()
     if getvalue:
         return getvalue()
+safe_dump_all = dump_all
+
+def danger_dump_all(documents, stream=None, **kwds):
+    """
+    Serialize a sequence of Python objects into a YAML stream.
+    Produce only basic YAML tags.
+    If stream is None, return the produced string instead.
+    """
+    return dump_all(documents, stream, Dumper=DangerDumper, **kwds)
 
 def dump(data, stream=None, Dumper=Dumper, **kwds):
     """
@@ -198,22 +215,15 @@ def dump(data, stream=None, Dumper=Dumper, **kwds):
     If stream is None, return the produced string instead.
     """
     return dump_all([data], stream, Dumper=Dumper, **kwds)
+safe_dump = dump
 
-def safe_dump_all(documents, stream=None, **kwds):
-    """
-    Serialize a sequence of Python objects into a YAML stream.
-    Produce only basic YAML tags.
-    If stream is None, return the produced string instead.
-    """
-    return dump_all(documents, stream, Dumper=SafeDumper, **kwds)
-
-def safe_dump(data, stream=None, **kwds):
+def danger_dump(data, stream=None, **kwds):
     """
     Serialize a Python object into a YAML stream.
     Produce only basic YAML tags.
     If stream is None, return the produced string instead.
     """
-    return dump_all([data], stream, Dumper=SafeDumper, **kwds)
+    return dump_all([data], stream, Dumper=DangerDumper, **kwds)
 
 def add_implicit_resolver(tag, regexp, first=None,
         Loader=Loader, Dumper=Dumper):

--- a/lib3/yaml/cyaml.py
+++ b/lib3/yaml/cyaml.py
@@ -1,6 +1,6 @@
 
-__all__ = ['CBaseLoader', 'CSafeLoader', 'CLoader',
-        'CBaseDumper', 'CSafeDumper', 'CDumper']
+__all__ = ['CBaseLoader', 'CSafeLoader', 'CLoader', 'CDangerLoader',
+        'CBaseDumper', 'CSafeDumper', 'CDumper', 'CDangerDumper']
 
 from _yaml import CParser, CEmitter
 
@@ -18,14 +18,15 @@ class CBaseLoader(CParser, BaseConstructor, BaseResolver):
         BaseConstructor.__init__(self)
         BaseResolver.__init__(self)
 
-class CSafeLoader(CParser, SafeConstructor, Resolver):
+class CLoader(CParser, SafeConstructor, Resolver):
 
     def __init__(self, stream):
         CParser.__init__(self, stream)
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
+CSafeLoader = CLoader
 
-class CLoader(CParser, Constructor, Resolver):
+class CDangerLoader(CParser, Constructor, Resolver):
 
     def __init__(self, stream):
         CParser.__init__(self, stream)
@@ -49,7 +50,7 @@ class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
 
-class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
+class CDumper(CEmitter, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -65,8 +66,9 @@ class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
         SafeRepresenter.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
+CSafeDumper = CDumper
 
-class CDumper(CEmitter, Serializer, Representer, Resolver):
+class CDangerDumper(CEmitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -82,4 +84,3 @@ class CDumper(CEmitter, Serializer, Representer, Resolver):
         Representer.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
-

--- a/lib3/yaml/dumper.py
+++ b/lib3/yaml/dumper.py
@@ -1,5 +1,5 @@
 
-__all__ = ['BaseDumper', 'SafeDumper', 'Dumper']
+__all__ = ['BaseDumper', 'SafeDumper', 'Dumper', 'DangerDumper']
 
 from .emitter import *
 from .serializer import *
@@ -24,7 +24,7 @@ class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
 
-class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
+class Dumper(Emitter, Serializer, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -41,8 +41,9 @@ class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
         SafeRepresenter.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
+SafeDumper = Dumper
 
-class Dumper(Emitter, Serializer, Representer, Resolver):
+class DangerDumper(Emitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,
@@ -59,4 +60,3 @@ class Dumper(Emitter, Serializer, Representer, Resolver):
         Representer.__init__(self, default_style=default_style,
                 default_flow_style=default_flow_style)
         Resolver.__init__(self)
-

--- a/lib3/yaml/loader.py
+++ b/lib3/yaml/loader.py
@@ -1,5 +1,5 @@
 
-__all__ = ['BaseLoader', 'SafeLoader', 'Loader']
+__all__ = ['BaseLoader', 'SafeLoader', 'Loader', 'DangerLoader']
 
 from .reader import *
 from .scanner import *
@@ -18,7 +18,7 @@ class BaseLoader(Reader, Scanner, Parser, Composer, BaseConstructor, BaseResolve
         BaseConstructor.__init__(self)
         BaseResolver.__init__(self)
 
-class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
+class Loader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
 
     def __init__(self, stream):
         Reader.__init__(self, stream)
@@ -27,8 +27,9 @@ class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
         Composer.__init__(self)
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
+SafeLoader = Loader
 
-class Loader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
+class DangerLoader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
 
     def __init__(self, stream):
         Reader.__init__(self, stream)
@@ -37,4 +38,3 @@ class Loader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
         Composer.__init__(self)
         Constructor.__init__(self)
         Resolver.__init__(self)
-

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -19,9 +19,9 @@ def _make_objects():
             NewArgs, NewArgsWithState, Reduce, ReduceWithState, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute
 
-    class MyLoader(yaml.Loader):
+    class MyLoader(yaml.DangerLoader):
         pass
-    class MyDumper(yaml.Dumper):
+    class MyDumper(yaml.DangerDumper):
         pass
 
     class MyTestClass1:
@@ -272,4 +272,3 @@ if __name__ == '__main__':
     sys.modules['test_constructor'] = sys.modules['__main__']
     import test_appliance
     test_appliance.run(globals())
-

--- a/tests/lib/test_recursive.py
+++ b/tests/lib/test_recursive.py
@@ -29,9 +29,9 @@ def test_recursive(recursive_filename, verbose=False):
     value2 = None
     output2 = None
     try:
-        output1 = yaml.dump(value1)
-        value2 = yaml.load(output1)
-        output2 = yaml.dump(value2)
+        output1 = yaml.danger_dump(value1)
+        value2 = yaml.danger_load(output1)
+        output2 = yaml.danger_dump(value2)
         assert output1 == output2, (output1, output2)
     finally:
         if verbose:
@@ -47,4 +47,3 @@ test_recursive.unittest = ['.recursive']
 if __name__ == '__main__':
     import test_appliance
     test_appliance.run(globals())
-

--- a/tests/lib3/test_constructor.py
+++ b/tests/lib3/test_constructor.py
@@ -16,9 +16,9 @@ def _make_objects():
             NewArgs, NewArgsWithState, Reduce, ReduceWithState, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute
 
-    class MyLoader(yaml.Loader):
+    class MyLoader(yaml.DangerLoader):
         pass
-    class MyDumper(yaml.Dumper):
+    class MyDumper(yaml.DangerDumper):
         pass
 
     class MyTestClass1:
@@ -257,4 +257,3 @@ if __name__ == '__main__':
     sys.modules['test_constructor'] = sys.modules['__main__']
     import test_appliance
     test_appliance.run(globals())
-

--- a/tests/lib3/test_recursive.py
+++ b/tests/lib3/test_recursive.py
@@ -30,9 +30,9 @@ def test_recursive(recursive_filename, verbose=False):
     value2 = None
     output2 = None
     try:
-        output1 = yaml.dump(value1)
-        value2 = yaml.load(output1)
-        output2 = yaml.dump(value2)
+        output1 = yaml.danger_dump(value1)
+        value2 = yaml.danger_load(output1)
+        output2 = yaml.danger_dump(value2)
         assert output1 == output2, (output1, output2)
     finally:
         if verbose:
@@ -48,4 +48,3 @@ test_recursive.unittest = ['.recursive']
 if __name__ == '__main__':
     import test_appliance
     test_appliance.run(globals())
-


### PR DESCRIPTION
Change yaml.load/yaml.dump to be yaml.safe_load/yaml.safe_dump, introduced yaml.danger_dump/yaml.danger_load, and the same for various other classes.

(python2 only at this moment)

Fixes #5