### PR TITLE
Drop unsupported Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache: pip
 
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27
     - python: 3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@
 #define=YAML_DECLARE_STATIC
 
 # The following options are used to build PyYAML Windows installer
-# for Python 2.6, 2.7, 3.0, 3.1 and 3.2 on my PC:
+# for Python 2.7, 3.0, 3.1 and 3.2 on my PC:
 #include_dirs=../../../libyaml/tags/0.1.4/include
 #library_dirs=../../../libyaml/tags/0.1.4/win32/vs2008/output/release/lib
 #define=YAML_DECLARE_STATIC

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.6",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.4",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35,py36
+envlist = py27,pypy,py33,py34,py35,py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Issue #47 says:

> Ansible (one of our largest downstream users on Python versions older than 2.6) is officially making all code only support 2.6 or newer in April 2017.

Well, now Ansible say:

> **Note**
> Ansible supports Python version 3.5 and above only.

https://docs.ansible.com/ansible/latest/python_3_support.html 

So Ansible no longer support Python 2.6. Coupled with the fact [Python 2.6 has been EOL since 2013](https://en.wikipedia.org/wiki/CPython#Version_history), means it can be dropped. Here are more reasons:

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* http://www.python3statement.org
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

Oh, and something has caused Python 2.6 builds to fail on Travis CI for latest master, so this of course resolves that too.