### PR TITLE
Drop unsupported Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35,py36
+envlist = py26,py27,pypy,py34,py35,py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Issue #47 says:

> Ansible (one of our largest downstream users on Python versions older than 2.6) is officially making all code only support 2.6 or newer in April 2017.

Well, now Ansible say:

> **Note**
> Ansible supports Python version 3.5 and above only.

https://docs.ansible.com/ansible/latest/python_3_support.html 

So Ansible no longer support Python 3.3 either. Coupled with the fact [Python 3.3 has been EOL since last month](https://en.wikipedia.org/wiki/CPython#Version_history), means it can be dropped. Here are more reasons:

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

(I also note that setup.py wasn't claiming Python 3.3 support, but perhaps that was an oversight when adding the classifiers in https://github.com/yaml/pyyaml/commit/16bd7d06c2cd4f2b688e2adc083b175595c03000.)