### PR TITLE
Update homepage link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ AUTHOR = "Kirill Simonov"
 AUTHOR_EMAIL = 'xi@resolvent.net'
 LICENSE = "MIT"
 PLATFORMS = "Any"
-URL = "http://pyyaml.org/wiki/PyYAML"
+URL = "https://github.com/yaml/pyyaml"
 DOWNLOAD_URL = "http://pyyaml.org/download/pyyaml/%s-%s.tar.gz" % (NAME, VERSION)
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
It contains broken links and is out of control of the project maintainers (see https://github.com/yaml/pyyaml/issues/79).

Instead link to this repo.

Should the pyyaml.org links in the README also be updated? https://github.com/hugovk/pyyaml/blob/patch-3/README#L21-L25

And the link at the top?

![image](https://user-images.githubusercontent.com/1324225/31318853-5e56e3ca-ac61-11e7-98f6-74d5266d4f1d.png)
