### PR TITLE
Avoiding overflow error on windows embedded Python

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -252,10 +252,8 @@ class SafeConstructor(BaseConstructor):
         else:
             return sign*int(value)
 
-    inf_value = 1e300
-    while inf_value != inf_value*inf_value:
-        inf_value *= inf_value
-    nan_value = -inf_value/inf_value   # Trying to make a quiet NaN (like C99).
+    inf_value = float('inf')
+    nan_value = float('nan')
 
     def construct_yaml_float(self, node):
         value = str(self.construct_scalar(node))

--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -182,9 +182,7 @@ class SafeRepresenter(BaseRepresenter):
     def represent_long(self, data):
         return self.represent_scalar(u'tag:yaml.org,2002:int', unicode(data))
 
-    inf_value = 1e300
-    while repr(inf_value) != repr(inf_value*inf_value):
-        inf_value *= inf_value
+    inf_value = float('inf')
 
     def represent_float(self, data):
         if data != data or (data == 0.0 and data == 1.0):

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -248,10 +248,8 @@ class SafeConstructor(BaseConstructor):
         else:
             return sign*int(value)
 
-    inf_value = 1e300
-    while inf_value != inf_value*inf_value:
-        inf_value *= inf_value
-    nan_value = -inf_value/inf_value   # Trying to make a quiet NaN (like C99).
+    inf_value = float('inf')
+    nan_value = float('nan')
 
     def construct_yaml_float(self, node):
         value = self.construct_scalar(node)

--- a/lib3/yaml/representer.py
+++ b/lib3/yaml/representer.py
@@ -162,9 +162,7 @@ class SafeRepresenter(BaseRepresenter):
     def represent_int(self, data):
         return self.represent_scalar('tag:yaml.org,2002:int', str(data))
 
-    inf_value = 1e300
-    while repr(inf_value) != repr(inf_value*inf_value):
-        inf_value *= inf_value
+    inf_value = float('inf')
 
     def represent_float(self, data):
         if data != data or (data == 0.0 and data == 1.0):


### PR DESCRIPTION
When running PyYaml on a windows app that runs with Python embedded  we receive a low-level overflow error with the implementations of inf_value and nan_value.
