### PR TITLE
Remove commented out Psyco code

### DIFF
--- a/lib/yaml/reader.py
+++ b/lib/yaml/reader.py
@@ -186,9 +186,3 @@ class Reader(object):
             self.stream_pointer += len(data)
         else:
             self.eof = True
-
-#try:
-#    import psyco
-#    psyco.bind(Reader)
-#except ImportError:
-#    pass

--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -1437,10 +1437,3 @@ class Scanner(object):
             self.forward()
             return ch
         return u''
-
-#try:
-#    import psyco
-#    psyco.bind(Scanner)
-#except ImportError:
-#    pass
-

--- a/lib3/yaml/reader.py
+++ b/lib3/yaml/reader.py
@@ -183,9 +183,3 @@ class Reader(object):
         self.stream_pointer += len(data)
         if not data:
             self.eof = True
-
-#try:
-#    import psyco
-#    psyco.bind(Reader)
-#except ImportError:
-#    pass

--- a/lib3/yaml/scanner.py
+++ b/lib3/yaml/scanner.py
@@ -1428,10 +1428,3 @@ class Scanner:
             self.forward()
             return ch
         return ''
-
-#try:
-#    import psyco
-#    psyco.bind(Scanner)
-#except ImportError:
-#    pass
-


### PR DESCRIPTION
From the [Psyco website](http://psyco.sourceforge.net/):

> 12 March 2012
>
> Psyco is unmaintained and dead. Please look at PyPy for the state-of-the-art in JIT compilers for Python.