### PR TITLE
On load, create timezone-aware datetime objects if possible

### DIFF
--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -330,9 +330,15 @@ class SafeConstructor(BaseConstructor):
             delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute)
             if values['tz_sign'] == '-':
                 delta = -delta
-        data = datetime.datetime(year, month, day, hour, minute, second, fraction)
-        if delta:
-            data -= delta
+        data = None
+        # If we are correcting to UTC, we can make the datetime object
+        # timezone-aware
+        if delta is not None:
+            data = datetime.datetime(year, month, day, hour, minute, second, fraction, datetime.timezone.utc)
+            if delta:
+                data -= delta
+        else:
+            data = datetime.datetime(year, month, day, hour, minute, second, fraction)
         return data
 
     def construct_yaml_omap(self, node):


### PR DESCRIPTION
On loading data, if timestamps have an ISO "+HH:MM" UTC offset then the resultant datetime is currently converted to UTC.  This change creates a **timezone-aware** datetime when this happens.  If there is no offset, a naive datetime is created as per the previous version.

Importantly, this addresses a Django warning (and potential error) that appears when using YAML fixtures in a timezone-aware project.  It was raised as a Django issue (https://code.djangoproject.com/ticket/18867), but subsequently closed because the Django devs felt that this is a PyYAML problem.