### PR TITLE
Added comment handling in Emitter (py3 only)

### DIFF
--- a/lib3/yaml/emitter.py
+++ b/lib3/yaml/emitter.py
@@ -76,6 +76,9 @@ class Emitter:
         self.whitespace = True
         self.indention = True
 
+        # Some comments shouldn't be written immediately, so we defer their value momentarily.
+        self.deferred_comment = None
+
         # Whether the document requires an explicit document indicator
         self.open_ended = False
 
@@ -116,23 +119,38 @@ class Emitter:
             self.event = None
 
     # In some cases, we wait for a few next events before emitting.
-
     def need_more_events(self):
         if not self.events:
             return True
-        event = self.events[0]
-        if isinstance(event, DocumentStartEvent):
-            return self.need_events(1)
+
+        event = None
+        offset = 0 
+        while offset < len(self.events):
+            if isinstance(self.events[offset], CommentEvent):
+                offset += 1
+            else:
+                event = self.events[offset]
+                break
+        else:
+            # It's all comments
+            return True
+
+        if isinstance(event, (DocumentStartEvent)):
+            return self.need_events(1, offset)
         elif isinstance(event, SequenceStartEvent):
-            return self.need_events(2)
+            return self.need_events(2, offset)
         elif isinstance(event, MappingStartEvent):
-            return self.need_events(3)
+            return self.need_events(3, offset)
         else:
             return False
 
-    def need_events(self, count):
+    def need_events(self, count, offset):
         level = 0
-        for event in self.events[1:]:
+        for event in self.events[offset+1:]:
+            if isinstance(event, (CommentEvent)):
+                # Each comment we see increases the total amount of events needed.
+                count += 1
+
             if isinstance(event, (DocumentStartEvent, CollectionStartEvent)):
                 level += 1
             elif isinstance(event, (DocumentEndEvent, CollectionEndEvent)):
@@ -141,7 +159,7 @@ class Emitter:
                 level = -1
             if level < 0:
                 return False
-        return (len(self.events) < count+1)
+        return (len(self.events) - offset < count+1)
 
     def increase_indent(self, flow=False, indentless=False):
         self.indents.append(self.indent)
@@ -257,6 +275,27 @@ class Emitter:
         else:
             raise EmitterError("expected NodeEvent, but got %s" % self.event)
 
+    def expect_comment(self, defer=False):
+        # Expect an entirely optional comment event. If the next event isn't
+        # one, then just continue. 
+        # If the comment is deferred, save the comment even for later processing.
+        # Returns True if there was a comment.
+        if isinstance(self.event, CommentEvent):
+            if not defer:
+                self.process_comment()
+            else:
+                if self.deferred_comment is not None:
+                    raise EmitterError("Tried to defer comment when one "
+                                       "already exists.\n"
+                                       "old: %s, new: %s" % 
+                                       (self.deferred_comment, self.event))
+                self.deferred_comment = self.event
+
+            self.event = self.events.pop(0)
+            return True
+        else:
+            return False
+
     def expect_alias(self):
         if self.event.anchor is None:
             raise EmitterError("anchor is not specified for alias")
@@ -278,18 +317,22 @@ class Emitter:
         self.state = self.expect_first_flow_sequence_item
 
     def expect_first_flow_sequence_item(self):
+        had_comment = self.expect_comment()
         if isinstance(self.event, SequenceEndEvent):
             self.indent = self.indents.pop()
             self.flow_level -= 1
             self.write_indicator(']', False)
             self.state = self.states.pop()
         else:
-            if self.canonical or self.column > self.best_width:
+            if (self.canonical or 
+                    self.column > self.best_width or 
+                    had_comment):
                 self.write_indent()
             self.states.append(self.expect_flow_sequence_item)
             self.expect_node(sequence=True)
 
     def expect_flow_sequence_item(self):
+        had_comment = self.expect_comment(defer=True)
         if isinstance(self.event, SequenceEndEvent):
             self.indent = self.indents.pop()
             self.flow_level -= 1
@@ -300,7 +343,10 @@ class Emitter:
             self.state = self.states.pop()
         else:
             self.write_indicator(',', False)
-            if self.canonical or self.column > self.best_width:
+            self.resolve_comment()
+            if (self.canonical or 
+                    self.column > self.best_width or
+                    had_comment):
                 self.write_indent()
             self.states.append(self.expect_flow_sequence_item)
             self.expect_node(sequence=True)
@@ -311,9 +357,11 @@ class Emitter:
         self.write_indicator('{', True, whitespace=True)
         self.flow_level += 1
         self.increase_indent(flow=True)
+        self.expect_comment()
         self.state = self.expect_first_flow_mapping_key
 
     def expect_first_flow_mapping_key(self):
+        self.expect_comment()
         if isinstance(self.event, MappingEndEvent):
             self.indent = self.indents.pop()
             self.flow_level -= 1
@@ -331,18 +379,21 @@ class Emitter:
                 self.expect_node(mapping=True)
 
     def expect_flow_mapping_key(self):
+        self.expect_comment(defer=True)
         if isinstance(self.event, MappingEndEvent):
             self.indent = self.indents.pop()
             self.flow_level -= 1
             if self.canonical:
                 self.write_indicator(',', False)
                 self.write_indent()
+            self.resolve_comment()
             self.write_indicator('}', False)
             self.state = self.states.pop()
         else:
             self.write_indicator(',', False)
             if self.canonical or self.column > self.best_width:
                 self.write_indent()
+            self.resolve_comment()
             if not self.canonical and self.check_simple_key():
                 self.states.append(self.expect_flow_mapping_simple_value)
                 self.expect_node(mapping=True, simple_key=True)
@@ -374,10 +425,13 @@ class Emitter:
         return self.expect_block_sequence_item(first=True)
 
     def expect_block_sequence_item(self, first=False):
+        self.expect_comment(defer=True)
         if not first and isinstance(self.event, SequenceEndEvent):
+            self.resolve_comment()
             self.indent = self.indents.pop()
             self.state = self.states.pop()
         else:
+            self.resolve_comment()
             self.write_indent()
             self.write_indicator('-', True, indention=True)
             self.states.append(self.expect_block_sequence_item)
@@ -393,10 +447,13 @@ class Emitter:
         return self.expect_block_mapping_key(first=True)
 
     def expect_block_mapping_key(self, first=False):
+        self.expect_comment(defer=True)
         if not first and isinstance(self.event, MappingEndEvent):
+            self.resolve_comment()
             self.indent = self.indents.pop()
             self.state = self.states.pop()
         else:
+            self.resolve_comment()
             self.write_indent()
             if self.check_simple_key():
                 self.states.append(self.expect_block_mapping_simple_value)
@@ -420,12 +477,24 @@ class Emitter:
     # Checkers.
 
     def check_empty_sequence(self):
-        return (isinstance(self.event, SequenceStartEvent) and self.events
-                and isinstance(self.events[0], SequenceEndEvent))
+        if isinstance(self.event, SequenceStartEvent):
+            i = 0
+            while (i < len(self.events) and 
+                isinstance(self.events[i], CommentEvent)):
+                i += 1
+            if i < len(self.events) and isinstance(self.events[i], SequenceEndEvent):
+                return True
+        return False
 
     def check_empty_mapping(self):
-        return (isinstance(self.event, MappingStartEvent) and self.events
-                and isinstance(self.events[0], MappingEndEvent))
+        if isinstance(self.event, MappingStartEvent):
+            i = 0
+            while (i < len(self.events) and 
+                    isinstance(self.events[i], CommentEvent)):
+                i += 1
+            if i < len(self.events) and isinstance(self.events[i], MappingEndEvent):
+                return True
+        return False
 
     def check_empty_document(self):
         if not isinstance(self.event, DocumentStartEvent) or not self.events:
@@ -454,7 +523,19 @@ class Emitter:
                     and not self.analysis.empty and not self.analysis.multiline)
             or self.check_empty_sequence() or self.check_empty_mapping()))
 
-    # Anchor, Tag, and Scalar processors.
+    # Anchor, Tag, Scalar and Comment processors.
+
+    def process_comment(self):
+        # Write the comment event's value. No other parameters needed.
+        self.write_comment(self.event.value)
+
+
+    def resolve_comment(self):
+        # Write the deferred comment, if any
+        if self.deferred_comment is not None:
+            self.write_comment(self.deferred_comment.value)
+            self.deferred_comment = None
+
 
     def process_anchor(self, indicator):
         if self.event.anchor is None:
@@ -848,6 +929,41 @@ class Emitter:
             data = data.encode(self.encoding)
         self.stream.write(data)
         self.write_line_break()
+
+    # Comment writing.
+
+    def write_comment(self, text):
+        # This is currently based on the 'write single quoted' string logic
+        breaks = True
+        start = end = 0
+        self.write_indent()
+        while end <= len(text):
+            ch = None
+            if end < len(text):
+                ch = text[end]
+            if breaks:
+                if ch is None or ch not in '\n\x85\u2028\u2029':
+                    for br in text[start:end]:
+                        if br == '\n':
+                            self.write_line_break()
+                        else:
+                            self.write_line_break(br)
+                    if ch is not None:
+                        self.write_indent()
+                        self.stream.write('# ')
+                    start = end
+            else:
+                if ch is None or ch in '\n\x85\u2028\u2029':
+                    data = text[start:end]
+                    if self.encoding:
+                        data = data.encode(self.encoding)
+                    self.stream.write(data)
+                    if ch is None:
+                        self.write_line_break()
+                    start = end
+            if ch is not None:
+                breaks = (ch in '\n\x85\u2028\u2029')
+            end += 1
 
     # Scalar streams.
 

--- a/lib3/yaml/events.py
+++ b/lib3/yaml/events.py
@@ -18,6 +18,23 @@ class NodeEvent(Event):
         self.start_mark = start_mark
         self.end_mark = end_mark
 
+
+class CommentEvent(NodeEvent):
+    # - Comment events are currently expected only before each key/value pair in 
+    # a map, and before each item in a sequence. 
+    # - These must be created directly in an event stream, there is no 
+    # way to designate them directly dumping python objects. 
+
+    def __init__(self, value):
+        self.anchor = None
+        self.tag = None
+        self.implicit = None
+        self.value = value
+        self.start_mark = None
+        self.end_mark = None
+        self.style = None
+
+
 class CollectionStartEvent(NodeEvent):
     def __init__(self, anchor, tag, implicit, start_mark=None, end_mark=None,
             flow_style=None):

--- a/tests/data/comments.events
+++ b/tests/data/comments.events
@@ -1,0 +1,101 @@
+- !StreamStart
+
+- !DocumentStart
+- !SequenceStart
+- !Comment { value: 'ok in empty sequence' }
+- !SequenceEnd
+- !DocumentEnd
+
+- !DocumentStart
+- !SequenceStart { tag: '!mytag', implicit: false }
+- !Comment { value: 'ok in empty sequence' }
+- !SequenceEnd
+- !DocumentEnd
+
+- !DocumentStart
+- !SequenceStart
+- !Comment { value: 'ok before first item in seq' }
+- !SequenceStart
+- !SequenceEnd
+- !SequenceStart { tag: '!mytag', implicit: false }
+- !SequenceEnd
+- !SequenceStart
+- !Comment { value: 'Comment before empty scalar' }
+- !Scalar
+- !Comment { value: 'Comment before Scalar' }
+- !Scalar { value: 'data' }
+- !Comment { value: 'Comment Before tagged scalar' }
+- !Scalar { tag: '!mytag', implicit: [false,false], value: 'data' }
+- !SequenceEnd
+- !Comment { value: 'Comment before deep list' }
+- !SequenceStart
+- !SequenceStart
+- !SequenceStart
+- !Scalar
+- !SequenceEnd
+- !SequenceEnd
+- !SequenceEnd
+- !SequenceStart
+- !SequenceStart { tag: '!mytag', implicit: false }
+- !SequenceStart
+- !Comment { value: 'Comment in deep list' }
+- !Scalar { value: 'data' }
+- !SequenceEnd
+- !SequenceEnd
+- !SequenceEnd
+- !SequenceEnd
+- !DocumentEnd
+
+- !DocumentStart
+- !SequenceStart
+- !MappingStart
+- !Comment { value: 'ok' }
+- !Scalar { value: 'key1' }
+- !SequenceStart
+- !Comment { value: 'ok in sub-seq' }
+- !Scalar { value: 'data1' }
+- !Scalar { value: 'data2' }
+- !SequenceEnd
+- !Comment { value: 'ok in front of second key' }
+- !Scalar { value: 'key2' }
+- !SequenceStart { tag: '!mytag1', implicit: false }
+- !Comment { value: 'ok in sub-seq 2' }
+- !Scalar { value: 'data3' }
+- !SequenceStart
+- !Comment { value: 'ok in sub-sub-seq 1' }
+- !Scalar { value: 'data4' }
+- !Comment { value: 'ok in sub-sub-seq 2' }
+- !Scalar { value: 'data5' }
+- !SequenceEnd
+- !SequenceStart { tag: '!mytag2', implicit: false }
+- !Comment { value: 'ok in sub-seq 3' }
+- !Scalar { value: 'data6' }
+- !Comment { value: 'ok in sub-seq 4' }
+- !Scalar { value: 'data7' }
+- !SequenceEnd
+- !SequenceEnd
+- !MappingEnd
+- !SequenceEnd
+- !DocumentEnd
+
+- !DocumentStart
+- !SequenceStart
+- !SequenceStart { flow_style: true }
+- !Comment { value: 'ok before sequence in sequence in flow style' }
+- !SequenceStart
+- !SequenceEnd
+- !Comment { value: 'ok in flow style' }
+- !Scalar
+- !Comment { value: 'ok in flow style2' }
+- !Scalar { value: 'data1' }
+- !Comment { value: 'ok in flow style3' }
+- !Scalar { tag: '!mytag', implicit: [false,false], value: 'data2' }
+- !SequenceStart { tag: '!mytag', implicit: false }
+- !Scalar { value: 'data3' }
+- !Scalar { value: 'data4' }
+- !SequenceEnd
+- !SequenceEnd
+- !SequenceEnd
+- !DocumentEnd
+
+- !StreamEnd

--- a/tests/lib3/test_emitter.py
+++ b/tests/lib3/test_emitter.py
@@ -10,7 +10,7 @@ def _compare_events(events1, events2):
         if isinstance(event1, yaml.CollectionStartEvent):
             assert event1.tag == event2.tag, (event1, event2)
         if isinstance(event1, yaml.ScalarEvent):
-            if True not in event1.implicit+event2.implicit:
+            if True not in tuple(event1.implicit)+tuple(event2.implicit):
                 assert event1.tag == event2.tag, (event1, event2)
             assert event1.value == event2.value, (event1, event2)
 
@@ -86,13 +86,16 @@ class EventsLoader(yaml.Loader):
 EventsLoader.add_constructor(None, EventsLoader.construct_event)
 
 def test_emitter_events(events_filename, verbose=False):
-    events = list(yaml.load(open(events_filename, 'rb'), Loader=EventsLoader))
+    events = tuple(yaml.load(open(events_filename, 'rb'), Loader=EventsLoader))
     output = yaml.emit(events)
     if verbose:
-        print("OUTPUT:")
+        print("OUTPUT:", events_filename)
         print(output)
     new_events = list(yaml.parse(output))
-    _compare_events(events, new_events)
+    no_comments = filter(lambda e: not isinstance(e, yaml.CommentEvent), events)
+    _compare_events(list(no_comments), new_events)
+
+test_emitter_events.unittest = ['.events']
 
 if __name__ == '__main__':
     import test_appliance


### PR DESCRIPTION
I'm writing a library for strictly defining YAML configurations, somewhat like you'd define a database schema in an SQL ORM. Part of this is allowing the system to write the configuration files and example configuration files given the structural definition (and the data, optionally), and the proper way to do that is using an existing YAML library (this one). There's one problem though, no library that I could find supports writing a YAML file with comments.

This is meant to change that. My library now builds the output yaml file as a series of events, with comments, and emits the results. 

The underlying purpose of this merge request is to start a discussion on this topic. If what I'm doing and the way I'm doing it is reasonable, I'll gladly port my changes to the python2 version of the library as well.

 - Comments can be added to an event stream before each
   item in a sequence or mapping, or in an empty one of
   either.
 - There shouldn't be any changes to the output in the absence of comments.
 - Added new CommentEvent
 - Added comment handling to emitter.py.
   - Mostly this involved changing the expect_block_*_item functions
   - The 'need_events' functions also had to be altered to act as if
     the comment events didn't exist in regard to figuring out whether
     more events were needed.
 - Re-enabled emitter tests, and added a new comment filled
   emitter test data file.