### PR TITLE
Remove call to `ord` in lib3 emitter code

### DIFF
--- a/lib3/yaml/emitter.py
+++ b/lib3/yaml/emitter.py
@@ -604,7 +604,7 @@ class Emitter:
                 start = end = end+1
                 data = ch.encode('utf-8')
                 for ch in data:
-                    chunks.append('%%%02X' % ord(ch))
+                    chunks.append('%%%02X' % ch)
         if start < end:
             chunks.append(suffix[start:end])
         suffix_text = ''.join(chunks)


### PR DESCRIPTION
Fixes issue #118 
`encode` produces a bytestring, and iterating over a bytestring in python 3 produces ints instead of chars