### PR TITLE
Test on Python 3.7-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7-dev
+      env: TOXENV=py37
     - python: pypy
       env: TOXENV=pypy
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35,py36
+envlist = py26,py27,pypy,py33,py34,py35,py36,py37
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes #144.

https://docs.travis-ci.com/user/languages/python/#Specifying-Python-versions

Python 3.7 is in beta with 3.7.0 final due on 2018-06-15.

https://www.python.org/dev/peps/pep-0537/#release-schedule