### PR TITLE
Remove redundant code in Scanner.peek_token()

### DIFF
--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -126,8 +126,7 @@ class Scanner(object):
         # Return the next token, but do not delete if from the queue.
         while self.need_more_tokens():
             self.fetch_more_tokens()
-        if self.tokens:
-            return self.tokens[0]
+        return self.tokens[0]
 
     def get_token(self):
         # Return the next token.

--- a/lib3/yaml/scanner.py
+++ b/lib3/yaml/scanner.py
@@ -126,8 +126,7 @@ class Scanner:
         # Return the next token, but do not delete if from the queue.
         while self.need_more_tokens():
             self.fetch_more_tokens()
-        if self.tokens:
-            return self.tokens[0]
+        return self.tokens[0]
 
     def get_token(self):
         # Return the next token.


### PR DESCRIPTION
Remove the code which does not do anything.
The result of the  'if' statement is always the same.