### PR TITLE
Fix handling of __slots__

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -560,7 +560,7 @@ class Constructor(SafeConstructor):
             elif state:
                 slotstate.update(state)
             for key, value in slotstate.items():
-                setattr(object, key, value)
+                setattr(instance, key, value)
 
     def construct_python_object(self, suffix, node):
         # Format:

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -567,7 +567,7 @@ class Constructor(SafeConstructor):
             elif state:
                 slotstate.update(state)
             for key, value in slotstate.items():
-                setattr(object, key, value)
+                setattr(instance, key, value)
 
     def construct_python_object(self, suffix, node):
         # Format:

--- a/tests/data/construct-python-object.code
+++ b/tests/data/construct-python-object.code
@@ -17,6 +17,8 @@ NewArgsWithState(1, 'two', [3,3,3]),
 Reduce(1, 'two', [3,3,3]),
 ReduceWithState(1, 'two', [3,3,3]),
 
+Slots(1, 'two', [3,3,3]),
+
 MyInt(3),
 MyList(3),
 MyDict(3),

--- a/tests/data/construct-python-object.data
+++ b/tests/data/construct-python-object.data
@@ -16,6 +16,8 @@
 - !!python/object/apply:test_constructor.Reduce [1, two, [3,3,3]]
 - !!python/object/apply:test_constructor.ReduceWithState { args: [1, two], state: [3,3,3] }
 
+- !!python/object/new:test_constructor.Slots { state: !!python/tuple [null, { foo: 1, bar: 'two', baz: [3,3,3] } ] }
+
 - !!python/object/new:test_constructor.MyInt [3]
 - !!python/object/new:test_constructor.MyList { listitems: [~, ~, ~] }
 - !!python/object/new:test_constructor.MyDict { dictitems: {0, 1, 2} }

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -16,7 +16,7 @@ def execute(code):
 def _make_objects():
     global MyLoader, MyDumper, MyTestClass1, MyTestClass2, MyTestClass3, YAMLObject1, YAMLObject2,  \
             AnObject, AnInstance, AState, ACustomState, InitArgs, InitArgsWithState,    \
-            NewArgs, NewArgsWithState, Reduce, ReduceWithState, MyInt, MyList, MyDict,  \
+            NewArgs, NewArgsWithState, Reduce, ReduceWithState, Slots, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute
 
     class MyLoader(yaml.DangerLoader):
@@ -184,6 +184,17 @@ def _make_objects():
             return self.__class__, (self.foo, self.bar), self.baz
         def __setstate__(self, state):
             self.baz = state
+
+    class Slots(object):
+        __slots__ = ("foo", "bar", "baz")
+        def __init__(self, foo=None, bar=None, baz=None):
+            self.foo = foo
+            self.bar = bar
+            self.baz = baz
+
+        def __eq__(self, other):
+            return type(self) is type(other) and \
+                (self.foo, self.bar, self.baz) == (other.foo, other.bar, other.baz)
 
     class MyInt(int):
         def __eq__(self, other):

--- a/tests/lib3/test_constructor.py
+++ b/tests/lib3/test_constructor.py
@@ -13,7 +13,7 @@ def execute(code):
 def _make_objects():
     global MyLoader, MyDumper, MyTestClass1, MyTestClass2, MyTestClass3, YAMLObject1, YAMLObject2,  \
             AnObject, AnInstance, AState, ACustomState, InitArgs, InitArgsWithState,    \
-            NewArgs, NewArgsWithState, Reduce, ReduceWithState, MyInt, MyList, MyDict,  \
+            NewArgs, NewArgsWithState, Reduce, ReduceWithState, Slots, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute
 
     class MyLoader(yaml.DangerLoader):
@@ -171,6 +171,17 @@ def _make_objects():
             return self.__class__, (self.foo, self.bar), self.baz
         def __setstate__(self, state):
             self.baz = state
+
+    class Slots:
+        __slots__ = ("foo", "bar", "baz")
+        def __init__(self, foo=None, bar=None, baz=None):
+            self.foo = foo
+            self.bar = bar
+            self.baz = baz
+
+        def __eq__(self, other):
+            return type(self) is type(other) and \
+                (self.foo, self.bar, self.baz) == (other.foo, other.bar, other.baz)
 
     class MyInt(int):
         def __eq__(self, other):


### PR DESCRIPTION
Loading the yaml of a dumped instance of a python class with `__slots__` raises a `TypeError` due to a typo in `constructor.py`.