### PR TITLE
allow emitting end of line spaces in literal block scalars

### DIFF
--- a/lib3/yaml/emitter.py
+++ b/lib3/yaml/emitter.py
@@ -18,7 +18,7 @@ class ScalarAnalysis:
     def __init__(self, scalar, empty, multiline,
             allow_flow_plain, allow_block_plain,
             allow_single_quoted, allow_double_quoted,
-            allow_block):
+            allow_literal_block, allow_folded_block):
         self.scalar = scalar
         self.empty = empty
         self.multiline = multiline
@@ -26,7 +26,8 @@ class ScalarAnalysis:
         self.allow_block_plain = allow_block_plain
         self.allow_single_quoted = allow_single_quoted
         self.allow_double_quoted = allow_double_quoted
-        self.allow_block = allow_block
+        self.allow_literal_block = allow_literal_block
+        self.allow_folded_block = allow_folded_block
 
 class Emitter:
 
@@ -502,9 +503,13 @@ class Emitter:
                 and (self.flow_level and self.analysis.allow_flow_plain
                     or (not self.flow_level and self.analysis.allow_block_plain))):
                 return ''
-        if self.event.style and self.event.style in '|>':
+        if self.event.style == '|':
             if (not self.flow_level and not self.simple_key_context
-                    and self.analysis.allow_block):
+                    and self.analysis.allow_literal_block):
+                return self.event.style
+        if self.event.style == '>':
+            if (not self.flow_level and not self.simple_key_context
+                    and self.analysis.allow_folded_block):
                 return self.event.style
         if not self.event.style or self.event.style == '\'':
             if (self.analysis.allow_single_quoted and
@@ -630,7 +635,7 @@ class Emitter:
             return ScalarAnalysis(scalar=scalar, empty=True, multiline=False,
                     allow_flow_plain=False, allow_block_plain=True,
                     allow_single_quoted=True, allow_double_quoted=True,
-                    allow_block=False)
+                    allow_literal_block=False, allow_folded_block = False)
 
         # Indicators and special characters.
         block_indicators = False
@@ -740,27 +745,30 @@ class Emitter:
         allow_block_plain = True
         allow_single_quoted = True
         allow_double_quoted = True
-        allow_block = True
+        allow_literal_block = True
+        allow_folded_block = True
 
         # Leading and trailing whitespaces are bad for plain scalars.
         if (leading_space or leading_break
                 or trailing_space or trailing_break):
             allow_flow_plain = allow_block_plain = False
 
-        # We do not permit trailing spaces for block scalars.
-        if trailing_space:
-            allow_block = False
-
-        # Spaces at the beginning of a new line are only acceptable for block
-        # scalars.
+        # Spaces at the beginning of a new line are only acceptable for double
+        # quoted and block scalars.
         if break_space:
             allow_flow_plain = allow_block_plain = allow_single_quoted = False
 
-        # Spaces followed by breaks, as well as special character are only
-        # allowed for double quoted scalars.
-        if space_break or special_characters:
+        # Spaces followed by breaks are only allowed for double quoted and
+        # literal block scalars.
+        if space_break:
             allow_flow_plain = allow_block_plain =  \
-            allow_single_quoted = allow_block = False
+            allow_single_quoted = allow_folded_block = False
+
+        # special character are only allowed for double quoted scalars.
+        if special_characters:
+            allow_flow_plain = allow_block_plain =  \
+            allow_single_quoted = allow_literal_block = \
+            allow_folded_block = False
 
         # Although the plain scalar writer supports breaks, we never emit
         # multiline plain scalars.
@@ -781,7 +789,8 @@ class Emitter:
                 allow_block_plain=allow_block_plain,
                 allow_single_quoted=allow_single_quoted,
                 allow_double_quoted=allow_double_quoted,
-                allow_block=allow_block)
+                allow_literal_block=allow_literal_block,
+                allow_folded_block=allow_folded_block)
 
     # Writers.
 


### PR DESCRIPTION
Fixes https://github.com/yaml/pyyaml/issues/121

This still rules out folding block scalars if there are spaces before line breaks, since the spec says a line cannot be folded there. I feel this implies such line breaks should be interpreted as real line breaks (i.e. it would be legal to emit this), but the spec doesn't seem to explicitly confirm this.

This does however allow folding block scalars if there is a content-final space, since I couldn't find anything in the spec against this.