### PR TITLE
Create timezone-aware datetimes when parsed as such

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -356,6 +356,9 @@ class SafeConstructor(BaseConstructor):
                 delta = -delta
             return datetime.datetime(year, month, day, hour, minute, second, fraction,
                                      tzinfo=timezone(delta))
+        elif values['tz']:
+            return datetime.datetime(year, month, day, hour, minute, second, fraction,
+                                     tzinfo=timezone(datetime.timedelta(0)))
         else:
             return datetime.datetime(year, month, day, hour, minute, second, fraction)
 

--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -343,6 +343,7 @@ class SafeConstructor(BaseConstructor):
         minute = int(values['minute'])
         second = int(values['second'])
         fraction = 0
+        tzinfo = None
         if values['fraction']:
             fraction = values['fraction'][:6]
             while len(fraction) < 6:
@@ -354,13 +355,11 @@ class SafeConstructor(BaseConstructor):
             delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute)
             if values['tz_sign'] == '-':
                 delta = -delta
-            return datetime.datetime(year, month, day, hour, minute, second, fraction,
-                                     tzinfo=timezone(delta))
+            tzinfo = timezone(delta)
         elif values['tz']:
-            return datetime.datetime(year, month, day, hour, minute, second, fraction,
-                                     tzinfo=timezone(datetime.timedelta(0)))
-        else:
-            return datetime.datetime(year, month, day, hour, minute, second, fraction)
+            tzinfo = timezone(datetime.timedelta(0))
+        return datetime.datetime(year, month, day, hour, minute, second, fraction,
+                                 tzinfo=tzinfo)
 
     def construct_yaml_omap(self, node):
         # Note: we do not check for duplicate keys, because it's too

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -337,6 +337,9 @@ class SafeConstructor(BaseConstructor):
                 delta = -delta
             return datetime.datetime(year, month, day, hour, minute, second, fraction,
                                      tzinfo=datetime.timezone(delta))
+        elif values['tz']:
+            return datetime.datetime(year, month, day, hour, minute, second, fraction,
+                                     tzinfo=datetime.timezone.utc)
         else:
             return datetime.datetime(year, month, day, hour, minute, second, fraction)
 

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -336,9 +336,15 @@ class SafeConstructor(BaseConstructor):
             delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute)
             if values['tz_sign'] == '-':
                 delta = -delta
-        data = datetime.datetime(year, month, day, hour, minute, second, fraction)
-        if delta:
-            data -= delta
+        data = None
+        # If we are correcting to UTC, we can make the datetime object
+        # timezone-aware
+        if delta is not None:
+            data = datetime.datetime(year, month, day, hour, minute, second, fraction, datetime.timezone.utc)
+            if delta:
+                data -= delta
+        else:
+            data = datetime.datetime(year, month, day, hour, minute, second, fraction)
         return data
 
     def construct_yaml_omap(self, node):

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -329,23 +329,16 @@ class SafeConstructor(BaseConstructor):
             while len(fraction) < 6:
                 fraction += '0'
             fraction = int(fraction)
-        delta = None
         if values['tz_sign']:
             tz_hour = int(values['tz_hour'])
             tz_minute = int(values['tz_minute'] or 0)
             delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute)
             if values['tz_sign'] == '-':
                 delta = -delta
-        data = None
-        # If we are correcting to UTC, we can make the datetime object
-        # timezone-aware
-        if delta is not None:
-            data = datetime.datetime(year, month, day, hour, minute, second, fraction, datetime.timezone.utc)
-            if delta:
-                data -= delta
+            return datetime.datetime(year, month, day, hour, minute, second, fraction,
+                                     tzinfo=datetime.timezone(delta))
         else:
-            data = datetime.datetime(year, month, day, hour, minute, second, fraction)
-        return data
+            return datetime.datetime(year, month, day, hour, minute, second, fraction)
 
     def construct_yaml_omap(self, node):
         # Note: we do not check for duplicate keys, because it's too

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -324,6 +324,7 @@ class SafeConstructor(BaseConstructor):
         minute = int(values['minute'])
         second = int(values['second'])
         fraction = 0
+        tzinfo = None
         if values['fraction']:
             fraction = values['fraction'][:6]
             while len(fraction) < 6:
@@ -335,13 +336,11 @@ class SafeConstructor(BaseConstructor):
             delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute)
             if values['tz_sign'] == '-':
                 delta = -delta
-            return datetime.datetime(year, month, day, hour, minute, second, fraction,
-                                     tzinfo=datetime.timezone(delta))
+            tzinfo = datetime.timezone(delta)
         elif values['tz']:
-            return datetime.datetime(year, month, day, hour, minute, second, fraction,
-                                     tzinfo=datetime.timezone.utc)
-        else:
-            return datetime.datetime(year, month, day, hour, minute, second, fraction)
+            tzinfo = datetime.timezone.utc
+        return datetime.datetime(year, month, day, hour, minute, second, fraction,
+                                 tzinfo=tzinfo)
 
     def construct_yaml_omap(self, node):
         # Note: we do not check for duplicate keys, because it's too


### PR DESCRIPTION
Includes commit by @cdavoren as [his PR](https://github.com/yaml/pyyaml/pull/113) triggered this (changes effectively overwritten).

- using `datetime.timezone()` for python3;
- using minimal `timezone()` for python2.

Old behaviour:

~~~~ python
>>> source = 'key: 2018-05-07T11:22:33+02:00'
>>> data = yaml.load(source)
>>> data['key']
datetime.datetime(2018, 5, 7, 9, 22, 33)
~~~~

New behaviour:

~~~~ python
>>> source = 'key: 2018-05-07T11:22:33+02:00'
>>> data = yaml.load(source)
>>> data['key']
datetime.datetime(2018, 5, 7, 11, 22, 33, tzinfo=datetime.timezone(datetime.timedelta(0, 7200)))
~~~~