### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,4 +295,5 @@ if __name__ == '__main__':
 
         distclass=Distribution,
         cmdclass=cmdclass,
+        python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     )


### PR DESCRIPTION
This helps pip install the correct distribution for the user's Python version.

This would be good for the 4.01 release, assuming https://github.com/yaml/pyyaml/pull/105 isn't merged (I think it'd be good to merge #105).