### PR TITLE
Import Hashable from collections.abc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,12 @@ For a complete changelog, see:
 * https://github.com/yaml/pyyaml/commits/
 * https://bitbucket.org/xi/pyyaml/commits/
 
+4.2 (unreleased)
+----------------
+
+* Fixed deprecation warning on Python 3.7 by importing from collections.abc
+  instead of collections.
+
 4.1 (2018-06-26)
 ----------------
 

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -5,7 +5,7 @@ __all__ = ['BaseConstructor', 'SafeConstructor', 'Constructor',
 from .error import *
 from .nodes import *
 
-import collections, datetime, base64, binascii, re, sys, types
+import collections.abc, datetime, base64, binascii, re, sys, types
 
 class ConstructorError(MarkedYAMLError):
     pass
@@ -123,7 +123,7 @@ class BaseConstructor:
         mapping = {}
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
-            if not isinstance(key, collections.Hashable):
+            if not isinstance(key, collections.abc.Hashable):
                 raise ConstructorError("while constructing a mapping", node.start_mark,
                         "found unhashable key", key_node.start_mark)
             value = self.construct_object(value_node, deep=deep)


### PR DESCRIPTION
In Python 3.7, importing ABCs directly from the `collections` module shows a
warning (and in Python 3.8 it will stop working) - see
https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320

Since this is only done in `lib3/` which is Python 3 only, we can unconditionally
import it from `collections.abc` instead.

This fixes the following `DeprecationWarning`:

```
.../site-packages/yaml/__init__.py:75: in load
    return loader.get_single_data()
.../site-packages/yaml/constructor.py:37: in get_single_data
    return self.construct_document(node)
.../site-packages/yaml/constructor.py:46: in construct_document
    for dummy in generator:
.../site-packages/yaml/constructor.py:398: in construct_yaml_map
    value = self.construct_mapping(node)
.../site-packages/yaml/constructor.py:204: in construct_mapping
    return super().construct_mapping(node, deep=deep)
.../site-packages/yaml/constructor.py:126: in construct_mapping
    if not isinstance(key, collections.Hashable):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'Hashable'

    def __getattr__(name):
        # For backwards compatibility, continue to make the collections ABCs
        # through Python 3.6 available through the collections module.
        # Note, no new collections ABCs were added in Python 3.7
        if name in _collections_abc.__all__:
            obj = getattr(_collections_abc, name)
            import warnings
            warnings.warn("Using or importing the ABCs from 'collections' instead "
                          "of from 'collections.abc' is deprecated, "
                          "and in 3.8 it will stop working",
>                         DeprecationWarning, stacklevel=2)
E           DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```