### PR TITLE
Build libyaml on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 before_script:
 - >-
   cd /tmp
-  && git clone https://github.com/yaml/libyaml.git -b 0.2.1 libyaml
+  && git clone https://github.com/yaml/libyaml.git -b 0.2.2-pre1 libyaml
   && cd libyaml
   && ./bootstrap
   && ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
   && ./bootstrap
   && ./configure
   && make
+  && make test-all
   && sudo make install
   && sudo ldconfig
   && cd "$TRAVIS_BUILD_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_script:
   && ./bootstrap
   && ./configure
   && make
+  && sudo make install
+  && sudo ldconfig
   && cd "$TRAVIS_BUILD_DIR"
 
 install: pip install cython tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,17 @@ matrix:
     - python: pypy
       env: TOXENV=pypy
 
-install: pip install tox
+# build libyaml
+before_script:
+- >-
+  cd /tmp
+  && git clone https://github.com/yaml/libyaml.git -b 0.2.1 libyaml
+  && cd libyaml
+  && ./bootstrap
+  && ./configure
+  && make
+  && cd "$TRAVIS_BUILD_DIR"
+
+install: pip install cython tox
 
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py26,py27,pypy,py34,py35,py36,py37
 
 [testenv]
-setenv =  LD_LIBRARY_PATH = /tmp/libyaml/src/.libs
 deps =
     Cython
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py26,py27,pypy,py34,py35,py36,py37
 
 [testenv]
+setenv =  LD_LIBRARY_PATH = /tmp/libyaml/src/.libs
 deps =
     Cython
 commands =


### PR DESCRIPTION
See also #60 and #184

We fetch the latest libyaml release and build it, so the tests
run both pure python and libyaml tests.

Tests are currently failing and should pass again when applying
https://github.com/yaml/libyaml/pull/122
(and adjusting the libyaml tag we are checking out in .travis.yml)

