### PR TITLE
Force cython when building sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ matrix:
     - python: pypy
       env: TOXENV=pypy
 
-install: pip install tox
+install: pip install cython tox
 
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -77,12 +77,16 @@ if 'setuptools.extension' in sys.modules:
     sys.modules['distutils.command.build_ext'].Extension = _Extension
 
 with_cython = False
+if 'sdist' in sys.argv:
+    # we need cython here
+    with_cython = True
 try:
     from Cython.Distutils.extension import Extension as _Extension
     from Cython.Distutils import build_ext as _build_ext
     with_cython = True
 except ImportError:
-    pass
+    if with_cython:
+        raise
 
 try:
     from wheel.bdist_wheel import bdist_wheel


### PR DESCRIPTION
This is the same as #188, but without adding the warning if cython
is not required.

