### PR TITLE
WIP: Another safe_load API attempt

### DIFF
--- a/examples/safe.py
+++ b/examples/safe.py
@@ -1,0 +1,30 @@
+import yaml
+import os
+
+def myconstructor(loader, node):
+    value = loader.construct_scalar(node)
+    os.system("echo hello " + value)
+    return value
+
+yaml.Loader.add_constructor(u'!hello', myconstructor)
+
+trusted_yaml = "mag: !hello world"
+
+print("============ Loading trusted YAML")
+
+data = yaml.load(trusted_yaml, Loader=yaml.Loader)
+print(data)
+
+
+# somewhere else in your application
+untrusted_yaml = "mag: !hello evil"
+
+print("============ Loading untrusted YAML")
+try:
+    safe_data = yaml.safe_load(untrusted_yaml)
+    print(safe_data)
+except yaml.constructor.ConstructorError as err:
+    print("Could not load unsafe_yaml:")
+    print(format(err))
+
+

--- a/examples/safe.py
+++ b/examples/safe.py
@@ -8,7 +8,7 @@ def myconstructor(loader, node):
 
 yaml.Loader.add_constructor(u'!hello', myconstructor)
 
-trusted_yaml = "mag: !hello world"
+trusted_yaml = "msg: !hello world"
 
 print("============ Loading trusted YAML")
 
@@ -17,7 +17,7 @@ print(data)
 
 
 # somewhere else in your application
-untrusted_yaml = "mag: !hello evil"
+untrusted_yaml = "msg: !hello evil"
 
 print("============ Loading untrusted YAML")
 try:

--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -74,7 +74,19 @@ def load(stream, Loader=Loader):
         return loader.get_single_data()
     finally:
         loader.dispose()
-safe_load = load
+
+def safe_load(stream):
+    """
+    Parse the first YAML document in a stream
+    and produce the corresponding Python object.
+
+    By default resolve only basic YAML tags
+    """
+    loader = SafeLoader(stream)
+    try:
+        return loader.get_single_data()
+    finally:
+        loader.dispose()
 
 def load_all(stream, Loader=Loader):
     """
@@ -90,7 +102,20 @@ def load_all(stream, Loader=Loader):
             yield loader.get_data()
     finally:
         loader.dispose()
-safe_load_all = load_all
+
+def safe_load_all(stream):
+    """
+    Parse all YAML documents in a stream
+    and produce corresponding Python objects.
+
+    By default resolve only basic YAML tags
+    """
+    loader = SafeLoader(stream)
+    try:
+        while loader.check_data():
+            yield loader.get_data()
+    finally:
+        loader.dispose()
 
 def danger_load(stream):
     """

--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -117,22 +117,6 @@ def safe_load_all(stream):
     finally:
         loader.dispose()
 
-def danger_load(stream):
-    """
-    Parse the first YAML document in a stream
-    and produce the corresponding Python object.
-    When used on untrusted input, can result in arbitrary code execution.
-    """
-    return load(stream, DangerLoader)
-
-def danger_load_all(stream):
-    """
-    Parse all YAML documents in a stream
-    and produce corresponding Python objects.
-    When used on untrusted input, can result in arbitrary code execution.
-    """
-    return load_all(stream, DangerLoader)
-
 def emit(events, stream=None, Dumper=Dumper,
         canonical=None, indent=None, width=None,
         allow_unicode=None, line_break=None):
@@ -228,14 +212,6 @@ def dump_all(documents, stream=None, Dumper=Dumper,
         return getvalue()
 safe_dump_all = dump_all
 
-def danger_dump_all(documents, stream=None, **kwds):
-    """
-    Serialize a sequence of Python objects into a YAML stream.
-    Produce only basic YAML tags.
-    If stream is None, return the produced string instead.
-    """
-    return dump_all(documents, stream, Dumper=DangerDumper, **kwds)
-
 def dump(data, stream=None, Dumper=Dumper, **kwds):
     """
     Serialize a Python object into a YAML stream.
@@ -243,14 +219,6 @@ def dump(data, stream=None, Dumper=Dumper, **kwds):
     """
     return dump_all([data], stream, Dumper=Dumper, **kwds)
 safe_dump = dump
-
-def danger_dump(data, stream=None, **kwds):
-    """
-    Serialize a Python object into a YAML stream.
-    Produce only basic YAML tags.
-    If stream is None, return the produced string instead.
-    """
-    return dump_all([data], stream, Dumper=DangerDumper, **kwds)
 
 def add_implicit_resolver(tag, regexp, first=None,
         Loader=Loader, Dumper=Dumper):

--- a/lib/yaml/cyaml.py
+++ b/lib/yaml/cyaml.py
@@ -24,7 +24,13 @@ class CLoader(CParser, SafeConstructor, Resolver):
         CParser.__init__(self, stream)
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
-CSafeLoader = CLoader
+
+class CSafeLoader(CParser, SafeConstructor, Resolver):
+
+    def __init__(self, stream):
+        CParser.__init__(self, stream)
+        SafeConstructor.__init__(self)
+        Resolver.__init__(self)
 
 class CDangerLoader(CParser, Constructor, Resolver):
 

--- a/lib/yaml/cyaml.py
+++ b/lib/yaml/cyaml.py
@@ -1,6 +1,6 @@
 
-__all__ = ['CBaseLoader', 'CSafeLoader', 'CLoader', 'CDangerLoader',
-        'CBaseDumper', 'CSafeDumper', 'CDumper', 'CDangerDumper']
+__all__ = ['CBaseLoader', 'CSafeLoader', 'CLoader', 'CPythonLoader',
+        'CBaseDumper', 'CSafeDumper', 'CDumper', 'CPythonDumper']
 
 from _yaml import CParser, CEmitter
 
@@ -32,7 +32,7 @@ class CSafeLoader(CParser, SafeConstructor, Resolver):
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
 
-class CDangerLoader(CParser, Constructor, Resolver):
+class CPythonLoader(CParser, Constructor, Resolver):
 
     def __init__(self, stream):
         CParser.__init__(self, stream)
@@ -74,7 +74,7 @@ class CDumper(CEmitter, SafeRepresenter, Resolver):
         Resolver.__init__(self)
 CSafeDumper = CDumper
 
-class CDangerDumper(CEmitter, Serializer, Representer, Resolver):
+class CPythonDumper(CEmitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,

--- a/lib/yaml/dumper.py
+++ b/lib/yaml/dumper.py
@@ -1,5 +1,5 @@
 
-__all__ = ['BaseDumper', 'SafeDumper', 'Dumper', 'DangerDumper']
+__all__ = ['BaseDumper', 'SafeDumper', 'Dumper', 'PythonDumper']
 
 from emitter import *
 from serializer import *
@@ -43,7 +43,7 @@ class Dumper(Emitter, Serializer, SafeRepresenter, Resolver):
         Resolver.__init__(self)
 SafeDumper = Dumper
 
-class DangerDumper(Emitter, Serializer, Representer, Resolver):
+class PythonDumper(Emitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=None,

--- a/lib/yaml/loader.py
+++ b/lib/yaml/loader.py
@@ -27,7 +27,16 @@ class Loader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
         Composer.__init__(self)
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
-SafeLoader = Loader
+
+class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
+
+    def __init__(self, stream):
+        Reader.__init__(self, stream)
+        Scanner.__init__(self)
+        Parser.__init__(self)
+        Composer.__init__(self)
+        SafeConstructor.__init__(self)
+        Resolver.__init__(self)
 
 class DangerLoader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
 

--- a/lib/yaml/loader.py
+++ b/lib/yaml/loader.py
@@ -1,5 +1,5 @@
 
-__all__ = ['BaseLoader', 'SafeLoader', 'Loader', 'DangerLoader']
+__all__ = ['BaseLoader', 'SafeLoader', 'Loader', 'PythonLoader']
 
 from reader import *
 from scanner import *
@@ -38,7 +38,7 @@ class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
         SafeConstructor.__init__(self)
         Resolver.__init__(self)
 
-class DangerLoader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
+class PythonLoader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
 
     def __init__(self, stream):
         Reader.__init__(self, stream)

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -19,9 +19,9 @@ def _make_objects():
             NewArgs, NewArgsWithState, Reduce, ReduceWithState, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute
 
-    class MyLoader(yaml.DangerLoader):
+    class MyLoader(yaml.PythonLoader):
         pass
-    class MyDumper(yaml.DangerDumper):
+    class MyDumper(yaml.PythonDumper):
         pass
 
     class MyTestClass1:

--- a/tests/lib/test_recursive.py
+++ b/tests/lib/test_recursive.py
@@ -29,9 +29,9 @@ def test_recursive(recursive_filename, verbose=False):
     value2 = None
     output2 = None
     try:
-        output1 = yaml.dump(value1, Dumper=yaml.DangerDumper)
-        value2 = yaml.load(output1, Loader=yaml.DangerLoader)
-        output2 = yaml.dump(value2, Dumper=yaml.DangerDumper)
+        output1 = yaml.dump(value1, Dumper=yaml.PythonDumper)
+        value2 = yaml.load(output1, Loader=yaml.PythonLoader)
+        output2 = yaml.dump(value2, Dumper=yaml.PythonDumper)
         assert output1 == output2, (output1, output2)
     finally:
         if verbose:

--- a/tests/lib/test_recursive.py
+++ b/tests/lib/test_recursive.py
@@ -29,9 +29,9 @@ def test_recursive(recursive_filename, verbose=False):
     value2 = None
     output2 = None
     try:
-        output1 = yaml.danger_dump(value1)
-        value2 = yaml.danger_load(output1)
-        output2 = yaml.danger_dump(value2)
+        output1 = yaml.dump(value1, Dumper=yaml.DangerDumper)
+        value2 = yaml.load(output1, Loader=yaml.DangerLoader)
+        output2 = yaml.dump(value2, Dumper=yaml.DangerDumper)
         assert output1 == output2, (output1, output2)
     finally:
         if verbose:


### PR DESCRIPTION
This is work in progress.
* It's fixing the issue mentioned in #187 , so `safe_load` will be as safe as before
* Remove danger_ shortcuts, so you have to use `load(..., Loader=LoaderClass)`
* Rename Danger* to Python*

The point behind renaming to Python* was, that in the future we could split up the PythonLoader class into a safe and a less safe one.
The current one will load arbitrary modules and will call any method/function.
I had the idea to make a safer version of that by only allowing creating instances of already loaded classes, and not calling methods. This is what I would expect a serializer to do.

I'm not sure yet if this is completely safe in Python, though. (In Perl it's not, because some objects can run code when they are garbage collected, so you can construct an exploit if you find a module that does something dangerous in its garbage collection handler.)

Then the less safer class could be named PythonCodeLoader or something like that.

Comments welcome