### PR TITLE
Enable testing of py37 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,12 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
+    - python: 3.7
       env: TOXENV=py37
+      # begin: workaround to enable support for py37:
+      sudo: required
+      dist: xenial
+      # end
     - python: pypy
       env: TOXENV=pypy
 


### PR DESCRIPTION
Activates py37 target in travis instead of the outdated 3.7-dev version.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>