### PR TITLE
Making python 3.7 + compatible

### DIFF
--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -5,7 +5,8 @@ __all__ = ['BaseConstructor', 'SafeConstructor', 'Constructor',
 from .error import *
 from .nodes import *
 
-import collections, datetime, base64, binascii, re, sys, types
+import datetime, base64, binascii, re, sys, types
+from collections import abc
 
 class ConstructorError(MarkedYAMLError):
     pass
@@ -123,7 +124,7 @@ class BaseConstructor:
         mapping = {}
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
-            if not isinstance(key, collections.Hashable):
+            if not isinstance(key, abc.Hashable):
                 raise ConstructorError("while constructing a mapping", node.start_mark,
                         "found unhashable key", key_node.start_mark)
             value = self.construct_object(value_node, deep=deep)


### PR DESCRIPTION
Python warning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working