### PR TITLE
Travis CI: Upgrade from Python 3.7 pre-release to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
+    - python: 3.7
       env: TOXENV=py37
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
     - python: pypy
       env: TOXENV=pypy
 


### PR DESCRIPTION
Upgrade to the production version of Python 3.7 in alignment with travis-ci/travis-ci#9069

Also see the note about outdated Python versions on Trusty at:
* https://docs.travis-ci.com/user/languages/python/#development-releases-support