### PR TITLE
Fix annoying DeprecationWarning in constructor.py

### DIFF
--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -5,7 +5,7 @@ __all__ = ['BaseConstructor', 'SafeConstructor', 'Constructor',
 from .error import *
 from .nodes import *
 
-import collections, datetime, base64, binascii, re, sys, types
+import collections.abc, datetime, base64, binascii, re, sys, types
 
 class ConstructorError(MarkedYAMLError):
     pass
@@ -123,7 +123,7 @@ class BaseConstructor:
         mapping = {}
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
-            if not isinstance(key, collections.Hashable):
+            if not isinstance(key, collections.abc.Hashable):
                 raise ConstructorError("while constructing a mapping", node.start_mark,
                         "found unhashable key", key_node.start_mark)
             value = self.construct_object(value_node, deep=deep)


### PR DESCRIPTION
Very annoying in Python 3.7

From [collections](https://docs.python.org/3/library/collections.html):

> Changed in version 3.3: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.