### PR TITLE
Add \u001b to the set of permitted unicode chars

### DIFF
--- a/lib3/yaml/emitter.py
+++ b/lib3/yaml/emitter.py
@@ -697,7 +697,8 @@ class Emitter:
             if ch in '\n\x85\u2028\u2029':
                 line_breaks = True
             if not (ch == '\n' or '\x20' <= ch <= '\x7E'):
-                if (ch == '\x85' or '\xA0' <= ch <= '\uD7FF'
+                if (ch == '\x85' or ch == '\u001B'
+                        or '\xA0' <= ch <= '\uD7FF'
                         or '\uE000' <= ch <= '\uFFFD'
                         or '\U00010000' <= ch < '\U0010ffff') and ch != '\uFEFF':
                     unicode_characters = True


### PR DESCRIPTION
This is used for colouring in many situations and thus useful with the block style (`style='|'`). If not in this set, then yaml will override any style setting from the user further down.

Are there consequences to this I am not aware of?