### PR TITLE
Check if regex for timestamp is correct match

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -304,6 +304,9 @@ class SafeConstructor(BaseConstructor):
     def construct_yaml_timestamp(self, node):
         value = self.construct_scalar(node)
         match = self.timestamp_regexp.match(node.value)
+        if match is None:
+            raise ConstructorError("while constructing a timestamp", node.start_mark,
+                                   "unable to parse the given %s" % node.id, node.start_mark)
         values = match.groupdict()
         year = int(values['year'])
         month = int(values['month'])

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -308,6 +308,9 @@ class SafeConstructor(BaseConstructor):
     def construct_yaml_timestamp(self, node):
         value = self.construct_scalar(node)
         match = self.timestamp_regexp.match(node.value)
+        if match is None:
+            raise ConstructorError("while constructing a timestamp", node.start_mark,
+                                   "unable to parse the given %s" % node.id, node.start_mark)
         values = match.groupdict()
         year = int(values['year'])
         month = int(values['month'])


### PR DESCRIPTION
Code now handles cases, when Constructor fails
to parse given scalar using timestamp regex.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>