### PR TITLE
Parse datetime timezone

### DIFF
--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -323,17 +323,17 @@ class SafeConstructor(BaseConstructor):
             while len(fraction) < 6:
                 fraction += '0'
             fraction = int(fraction)
-        delta = None
+
+        tzinfo = None
         if values['tz_sign']:
             tz_hour = int(values['tz_hour'])
             tz_minute = int(values['tz_minute'] or 0)
             delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute)
             if values['tz_sign'] == '-':
                 delta = -delta
-        data = datetime.datetime(year, month, day, hour, minute, second, fraction)
-        if delta:
-            data -= delta
-        return data
+            tzinfo = datetime.timezone(delta)
+
+        return datetime.datetime(year, month, day, hour, minute, second, fraction, tzinfo=tzinfo)
 
     def construct_yaml_omap(self, node):
         # Note: we do not check for duplicate keys, because it's too


### PR DESCRIPTION
Add timezone when parse datetime

When I load an yaml like `yaml.load("2018-02-11 19:00:00-02:00")`

I got
> 2018-02-11 21:00:00

Instead of
> 2018-02-11 19:00:00-02:00
