### PR TITLE
Make default_flow_style=False

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -161,7 +161,7 @@ def serialize(node, stream=None, Dumper=Dumper, **kwds):
     return serialize_all([node], stream, Dumper=Dumper, **kwds)
 
 def dump_all(documents, stream=None, Dumper=Dumper,
-        default_style=None, default_flow_style=None,
+        default_style=None, default_flow_style=False,
         canonical=None, indent=None, width=None,
         allow_unicode=None, line_break=None,
         encoding='utf-8', explicit_start=None, explicit_end=None,

--- a/lib/yaml/cyaml.py
+++ b/lib/yaml/cyaml.py
@@ -35,7 +35,7 @@ class CLoader(CParser, Constructor, Resolver):
 class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -52,7 +52,7 @@ class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
 class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -69,7 +69,7 @@ class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
 class CDumper(CEmitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,

--- a/lib/yaml/dumper.py
+++ b/lib/yaml/dumper.py
@@ -9,7 +9,7 @@ from resolver import *
 class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -27,7 +27,7 @@ class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
 class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -45,7 +45,7 @@ class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
 class Dumper(Emitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,

--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -17,7 +17,7 @@ class BaseRepresenter(object):
     yaml_representers = {}
     yaml_multi_representers = {}
 
-    def __init__(self, default_style=None, default_flow_style=None):
+    def __init__(self, default_style=None, default_flow_style=False):
         self.default_style = default_style
         self.default_flow_style = default_flow_style
         self.represented_objects = {}

--- a/lib3/yaml/__init__.py
+++ b/lib3/yaml/__init__.py
@@ -160,7 +160,7 @@ def serialize(node, stream=None, Dumper=Dumper, **kwds):
     return serialize_all([node], stream, Dumper=Dumper, **kwds)
 
 def dump_all(documents, stream=None, Dumper=Dumper,
-        default_style=None, default_flow_style=None,
+        default_style=None, default_flow_style=False,
         canonical=None, indent=None, width=None,
         allow_unicode=None, line_break=None,
         encoding=None, explicit_start=None, explicit_end=None,

--- a/lib3/yaml/cyaml.py
+++ b/lib3/yaml/cyaml.py
@@ -35,7 +35,7 @@ class CLoader(CParser, Constructor, Resolver):
 class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -52,7 +52,7 @@ class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
 class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -69,7 +69,7 @@ class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
 class CDumper(CEmitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,

--- a/lib3/yaml/dumper.py
+++ b/lib3/yaml/dumper.py
@@ -9,7 +9,7 @@ from .resolver import *
 class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -27,7 +27,7 @@ class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
 class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
@@ -45,7 +45,7 @@ class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
 class Dumper(Emitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=None,
+            default_style=None, default_flow_style=False,
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,

--- a/lib3/yaml/representer.py
+++ b/lib3/yaml/representer.py
@@ -15,7 +15,7 @@ class BaseRepresenter:
     yaml_representers = {}
     yaml_multi_representers = {}
 
-    def __init__(self, default_style=None, default_flow_style=None):
+    def __init__(self, default_style=None, default_flow_style=False):
         self.default_style = default_style
         self.default_flow_style = default_flow_style
         self.represented_objects = {}


### PR DESCRIPTION
See #199

`False` will output block style always.
`True` will output flow style always.
`None` will output flow style only for the collections which consists
only of scalars.

    data = dict( a=dict(aa=dict(aaa = ['x','y']), ab=42) )
    print( yaml.dump( data ) )
    print( yaml.dump( data, default_flow_style=True ) )
    print( yaml.dump( data, default_flow_style=False ) )
    print( yaml.dump( data, default_flow_style=None ) )

Output:


    a:
      aa:
        aaa:
        - x
        - y
      ab: 42

    {a: {aa: {aaa: [x, y]}, ab: 42}}

    a:
      aa:
        aaa:
        - x
        - y
      ab: 42

    a:
      aa:
        aaa: [x, y]
      ab: 42


