### PR TITLE
fix yaml construct a slot object

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -560,7 +560,7 @@ class Constructor(SafeConstructor):
             elif state:
                 slotstate.update(state)
             for key, value in slotstate.items():
-                setattr(object, key, value)
+                setattr(instance, key, value)
 
     def construct_python_object(self, suffix, node):
         # Format:

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -567,7 +567,7 @@ class Constructor(SafeConstructor):
             elif state:
                 slotstate.update(state)
             for key, value in slotstate.items():
-                setattr(object, key, value)
+                setattr(instance, key, value)
 
     def construct_python_object(self, suffix, node):
         # Format:

--- a/tests/data/construct-python-object.code
+++ b/tests/data/construct-python-object.code
@@ -8,6 +8,8 @@ AnInstance(1, 'two', [3,3,3]),
 AState(1, 'two', [3,3,3]),
 ACustomState(1, 'two', [3,3,3]),
 
+AnInstanceWithSlots(1, 'two', [3,3,3]),
+
 InitArgs(1, 'two', [3,3,3]),
 InitArgsWithState(1, 'two', [3,3,3]),
 

--- a/tests/data/construct-python-object.data
+++ b/tests/data/construct-python-object.data
@@ -7,6 +7,8 @@
 - !!python/object:test_constructor.AState { _foo: 1, _bar: two, _baz: [3,3,3] }
 - !!python/object/new:test_constructor.ACustomState { state: !!python/tuple [1, two, [3,3,3]] }
 
+- !!python/object/new:test_constructor.AnInstanceWithSlots {state: !!python/tuple [null, {bar: two, baz: [3, 3, 3], foo: 1}]}
+
 - !!python/object/new:test_constructor.InitArgs [1, two, [3,3,3]]
 - !!python/object/new:test_constructor.InitArgsWithState { args: [1, two], state: [3,3,3] }
 

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -15,7 +15,7 @@ def execute(code):
 
 def _make_objects():
     global MyLoader, MyDumper, MyTestClass1, MyTestClass2, MyTestClass3, YAMLObject1, YAMLObject2,  \
-            AnObject, AnInstance, AState, ACustomState, InitArgs, InitArgsWithState,    \
+            AnObject, AnInstance, AState, ACustomState, AnInstanceWithSlots, InitArgs, InitArgsWithState,    \
             NewArgs, NewArgsWithState, Reduce, ReduceWithState, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute
 
@@ -146,6 +146,22 @@ def _make_objects():
             return (self.foo, self.bar, self.baz)
         def __setstate__(self, state):
             self.foo, self.bar, self.baz = state
+
+    class AnInstanceWithSlots(object):
+        __slots__ = ('foo', 'bar', 'baz')
+
+        def __init__(self, foo=None, bar=None, baz=None):
+            self.foo = foo
+            self.bar = bar
+            self.baz = baz
+
+        def __cmp__(self, other):
+            return cmp((type(self), self.foo, self.bar, self.baz),
+                    (type(other), other.foo, other.bar, other.baz))
+
+        def __eq__(self, other):
+            return type(self) is type(other) and    \
+                    (self.foo, self.bar, self.baz) == (other.foo, other.bar, other.baz)
 
     class InitArgs(AnInstance):
         def __getinitargs__(self):

--- a/tests/lib3/test_constructor.py
+++ b/tests/lib3/test_constructor.py
@@ -12,7 +12,7 @@ def execute(code):
 
 def _make_objects():
     global MyLoader, MyDumper, MyTestClass1, MyTestClass2, MyTestClass3, YAMLObject1, YAMLObject2,  \
-            AnObject, AnInstance, AState, ACustomState, InitArgs, InitArgsWithState,    \
+            AnObject, AnInstance, AState, ACustomState, AnInstanceWithSlots, InitArgs, InitArgsWithState,    \
             NewArgs, NewArgsWithState, Reduce, ReduceWithState, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute
 
@@ -143,6 +143,22 @@ def _make_objects():
             return (self.foo, self.bar, self.baz)
         def __setstate__(self, state):
             self.foo, self.bar, self.baz = state
+
+    class AnInstanceWithSlots(object):
+        __slots__ = ('foo', 'bar', 'baz')
+
+        def __init__(self, foo=None, bar=None, baz=None):
+            self.foo = foo
+            self.bar = bar
+            self.baz = baz
+
+        def __cmp__(self, other):
+            return cmp((type(self), self.foo, self.bar, self.baz),
+                    (type(other), other.foo, other.bar, other.baz))
+
+        def __eq__(self, other):
+            return type(self) is type(other) and    \
+                    (self.foo, self.bar, self.baz) == (other.foo, other.bar, other.baz)
 
     class NewArgs(AnObject):
         def __getnewargs__(self):


### PR DESCRIPTION
Env:
- Python 3.7
- pyyaml master branch

Test code:

```Python
import yaml


class A:
    __slots__ = ('c',)

    def __init__(self):
        self.c = 3


data = yaml.dump({'a': A()})
d = yaml.load(data)
```

Trackback:

```
Traceback (most recent call last):
  File "t.py", line 12, in <module>
    d = yaml.load(data)
  File "/root/py36/lib/python3.7/site-packages/yaml/__init__.py", line 72, in load
    return loader.get_single_data()
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 37, in get_single_data
    return self.construct_document(node)
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 46, in construct_document
    for dummy in generator:
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 398, in construct_yaml_map
    value = self.construct_mapping(node)
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 204, in construct_mapping
    return super().construct_mapping(node, deep=deep)
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 129, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 88, in construct_object
    data = constructor(self, tag_suffix, node)
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 617, in construct_python_object_new
    return self.construct_python_object_apply(suffix, node, newobj=True)
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 608, in construct_python_object_apply
    self.set_python_instance_state(instance, state)
  File "/root/py36/lib/python3.7/site-packages/yaml/constructor.py", line 570, in set_python_instance_state
    setattr(object, key, value)
TypeError: can't set attributes of built-in/extension type 'object'
```

The exception was throwed from [#L570](https://github.com/yaml/pyyaml/blob/ccc40f3e2ba384858c0d32263ac3e3a6626ab15e/lib3/yaml/constructor.py#L570)

https://github.com/yaml/pyyaml/blob/ccc40f3e2ba384858c0d32263ac3e3a6626ab15e/lib3/yaml/constructor.py#L558-L570

I think `object` should be `instance`.
