### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,11 @@ matrix:
       env: TOXENV=py38
     - python: pypy
       env: TOXENV=pypy
+    - python: pypy-3.5
+      env: TOXENV=pypy3.5
   allow_failures:
     - python: pypy
+    - python: pypy-3.5
     - python: 3.8-dev
 
 # build libyaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-# dist: xenial
-
 language: python
 
 sudo: false
@@ -22,6 +20,9 @@ matrix:
       env: TOXENV=py38
     - python: pypy
       env: TOXENV=pypy
+  allow_failures:
+    - python: pypy
+    - python: 3.8-dev
 
 # build libyaml
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37
+envlist = py27,pypy,py34,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
- Added Python 3.8 dev and Pypy 3.5 to test environments
- Added Python 3.8 dev and Pypy 3.5 as allowed failures

Also, considering that the tests with Pypy are passing, should I remove them from the `allowed_failure` section?