### PR TITLE
Change default loader for YAMLObject classes to FullLoader

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -383,7 +383,7 @@ class YAMLObject(object):
     __metaclass__ = YAMLObjectMetaclass
     __slots__ = ()  # no direct instantiation, so allow immutable subclasses
 
-    yaml_loader = Loader
+    yaml_loader = FullLoader
     yaml_dumper = Dumper
 
     yaml_tag = None

--- a/lib3/yaml/__init__.py
+++ b/lib3/yaml/__init__.py
@@ -379,7 +379,7 @@ class YAMLObject(metaclass=YAMLObjectMetaclass):
 
     __slots__ = ()  # no direct instantiation, so allow immutable subclasses
 
-    yaml_loader = Loader
+    yaml_loader = FullLoader
     yaml_dumper = Dumper
 
     yaml_tag = None


### PR DESCRIPTION
Fixes #266

The default loader for `yaml.load` is yaml.FullLoader, so the default
for the YAMLObject class should also be changed.


