### PR TITLE
Fix logic for quoting special characters

### DIFF
--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -706,7 +706,7 @@ class Emitter(object):
             if not (ch == u'\n' or u'\x20' <= ch <= u'\x7E'):
                 if (ch == u'\x85' or u'\xA0' <= ch <= u'\uD7FF'
                         or u'\uE000' <= ch <= u'\uFFFD'
-                        or ((not has_ucs4) or (u'\U00010000' <= ch < u'\U0010ffff'))) and ch != u'\uFEFF':
+                        or ((not has_ucs4) and (u'\U00010000' <= ch < u'\U0010ffff'))) and ch != u'\uFEFF':
                     unicode_characters = True
                     if not self.allow_unicode:
                         special_characters = True

--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -706,7 +706,7 @@ class Emitter(object):
             if not (ch == u'\n' or u'\x20' <= ch <= u'\x7E'):
                 if (ch == u'\x85' or u'\xA0' <= ch <= u'\uD7FF'
                         or u'\uE000' <= ch <= u'\uFFFD'
-                        or ((not has_ucs4) and (u'\U00010000' <= ch < u'\U0010ffff'))) and ch != u'\uFEFF':
+                        or (u'\U00010000' <= ch < u'\U0010ffff')) and ch != u'\uFEFF':
                     unicode_characters = True
                     if not self.allow_unicode:
                         special_characters = True


### PR DESCRIPTION
Fixes #275

Currently some strings with special characters are dumped as plain strings, on systems where `sys.maxunicode <= 0xffff` (typically Python 2.7 on Win/Mac) and when using `allow_unicode=True`. That doesn't roundtrip.

```
>>> import yaml
>>> string = "\tpart1\tpart2"
>>> print(yaml.dump(string, allow_unicode=True))

        part1   part2
...
```