### PR TITLE
Specify YAMLError

### DIFF
--- a/ext/_yaml.pyx
+++ b/ext/_yaml.pyx
@@ -86,7 +86,7 @@ cdef class Mark:
                 % (self.name, self.line+1, self.column+1)
         return where
 
-#class YAMLError(Exception):
+#class YAMLError(ValueError):
 #    pass
 #
 #class MarkedYAMLError(YAMLError):

--- a/lib/yaml/error.py
+++ b/lib/yaml/error.py
@@ -42,7 +42,7 @@ class Mark(object):
             where += ":\n"+snippet
         return where
 
-class YAMLError(Exception):
+class YAMLError(ValueError):
     pass
 
 class MarkedYAMLError(YAMLError):

--- a/lib3/yaml/error.py
+++ b/lib3/yaml/error.py
@@ -42,7 +42,7 @@ class Mark:
             where += ":\n"+snippet
         return where
 
-class YAMLError(Exception):
+class YAMLError(ValueError):
     pass
 
 class MarkedYAMLError(YAMLError):


### PR DESCRIPTION
Hello

While handling exceptions from import/export with variable, user-defined format, I noticed the highest common denominator for YAMLError and JSONError is just Exception, while IMHO it has all the prerequisites of being an ValueError.

Feel free to modify this PR at your convenience.