### PR TITLE
A more flexible fix for custom tag constructors

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -371,7 +371,12 @@ class YAMLObjectMetaclass(type):
     def __init__(cls, name, bases, kwds):
         super(YAMLObjectMetaclass, cls).__init__(name, bases, kwds)
         if 'yaml_tag' in kwds and kwds['yaml_tag'] is not None:
-            cls.yaml_loader.add_constructor(cls.yaml_tag, cls.from_yaml)
+            if isinstance(cls.yaml_loader, list):
+                for loader in cls.yaml_loader:
+                    loader.add_constructor(cls.yaml_tag, cls.from_yaml)
+            else:
+                cls.yaml_loader.add_constructor(cls.yaml_tag, cls.from_yaml)
+
             cls.yaml_dumper.add_representer(cls, cls.to_yaml)
 
 class YAMLObject(object):
@@ -383,7 +388,7 @@ class YAMLObject(object):
     __metaclass__ = YAMLObjectMetaclass
     __slots__ = ()  # no direct instantiation, so allow immutable subclasses
 
-    yaml_loader = Loader
+    yaml_loader = [Loader, FullLoader, UnsafeLoader]
     yaml_dumper = Dumper
 
     yaml_tag = None

--- a/lib3/yaml/__init__.py
+++ b/lib3/yaml/__init__.py
@@ -368,7 +368,12 @@ class YAMLObjectMetaclass(type):
     def __init__(cls, name, bases, kwds):
         super(YAMLObjectMetaclass, cls).__init__(name, bases, kwds)
         if 'yaml_tag' in kwds and kwds['yaml_tag'] is not None:
-            cls.yaml_loader.add_constructor(cls.yaml_tag, cls.from_yaml)
+            if isinstance(cls.yaml_loader, list):
+                for loader in cls.yaml_loader:
+                    loader.add_constructor(cls.yaml_tag, cls.from_yaml)
+            else:
+                cls.yaml_loader.add_constructor(cls.yaml_tag, cls.from_yaml)
+
             cls.yaml_dumper.add_representer(cls, cls.to_yaml)
 
 class YAMLObject(metaclass=YAMLObjectMetaclass):
@@ -379,7 +384,7 @@ class YAMLObject(metaclass=YAMLObjectMetaclass):
 
     __slots__ = ()  # no direct instantiation, so allow immutable subclasses
 
-    yaml_loader = Loader
+    yaml_loader = [Loader, FullLoader, UnsafeLoader]
     yaml_dumper = Dumper
 
     yaml_tag = None


### PR DESCRIPTION
For #266 and #271. Replaces #273.

The `yaml_loader` class variable can be a list of loaders.
The `YAMLObject` helper class targets all the loader classes except SafeLoader.

Here's a test script that works. Uncomment the comments to support SafeLoader:
```
    #!/usr/bin/env python
    import yaml

    class Monster(yaml.YAMLObject):
        yaml_tag = u'!Monster'

        # yaml_loader = yaml.YAMLObject.yaml_loader
        # yaml_loader.append(yaml.SafeLoader)

        def __init__(self, name, hp, ac, attacks):
            self.name = name
            self.hp = hp
            self.ac = ac
            self.attacks = attacks
        def __repr__(self):
            return "%s(name=%r, hp=%r, ac=%r, attacks=%r)" % (
                self.__class__.__name__, self.name, self.hp, self.ac, self.attacks)

    input = """
    --- !Monster
    name: Cave spider
    hp: [2,6]    # 2d6
    ac: 16
    attacks: [BITE, HURT]
    """

    print(yaml.load(input))
    print(yaml.load(input, Loader=yaml.Loader))

    print(yaml.full_load(input))
    print(yaml.load(input, Loader=yaml.FullLoader))

    print(yaml.unsafe_load(input))
    print(yaml.load(input, Loader=yaml.UnsafeLoader))

    # print(yaml.safe_load(input))
    # print(yaml.load(input, Loader=yaml.SafeLoader))
```

Here is output:
```
$ PYTHONPATH=lib3 python3 test.py
test.py:27: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  print(yaml.load(input))
Monster(name='Cave spider', hp=[2, 6], ac=16, attacks=['BITE', 'HURT'])
Monster(name='Cave spider', hp=[2, 6], ac=16, attacks=['BITE', 'HURT'])
Monster(name='Cave spider', hp=[2, 6], ac=16, attacks=['BITE', 'HURT'])
Monster(name='Cave spider', hp=[2, 6], ac=16, attacks=['BITE', 'HURT'])
Monster(name='Cave spider', hp=[2, 6], ac=16, attacks=['BITE', 'HURT'])
Monster(name='Cave spider', hp=[2, 6], ac=16, attacks=['BITE', 'HURT'])
```

Works with Python 2 as well.




