### PR TITLE
Add use of safe_load() function in README

### DIFF
--- a/README
+++ b/README
@@ -15,6 +15,10 @@ parser and emitter as follows:
     >>> yaml.load(stream, Loader=yaml.CLoader)
     >>> yaml.dump(data, Dumper=yaml.CDumper)
 
+If you don't trust the input stream, you should use:
+
+    >>> yaml.safe_load(stream)
+
 PyYAML includes a comprehensive test suite.  To run the tests,
 type 'python setup.py test'.
 


### PR DESCRIPTION
It helps people to use `safe_load` if they discover the library.
It's more secure if `safe_load()` is used by default, and `load()` is used if it's necessary (and the developer knows what is does).