### PR TITLE
Change default loader for yaml.add_constructor

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -342,14 +342,19 @@ def add_constructor(tag, constructor, Loader=None):
     else:
         Loader.add_constructor(tag, constructor)
 
-def add_multi_constructor(tag_prefix, multi_constructor, Loader=Loader):
+def add_multi_constructor(tag_prefix, multi_constructor, Loader=None):
     """
     Add a multi-constructor for the given tag prefix.
     Multi-constructor is called for a node if its tag starts with tag_prefix.
     Multi-constructor accepts a Loader instance, a tag suffix,
     and a node object and produces the corresponding Python object.
     """
-    Loader.add_multi_constructor(tag_prefix, multi_constructor)
+    if Loader == None:
+        loader.Loader.add_multi_constructor(tag_prefix, multi_constructor)
+        loader.FullLoader.add_multi_constructor(tag_prefix, multi_constructor)
+        loader.UnsafeLoader.add_multi_constructor(tag_prefix, multi_constructor)
+    else:
+        Loader.add_multi_constructor(tag_prefix, multi_constructor)
 
 def add_representer(data_type, representer, Dumper=Dumper):
     """

--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -329,13 +329,18 @@ def add_path_resolver(tag, path, kind=None, Loader=Loader, Dumper=Dumper):
     Loader.add_path_resolver(tag, path, kind)
     Dumper.add_path_resolver(tag, path, kind)
 
-def add_constructor(tag, constructor, Loader=Loader):
+def add_constructor(tag, constructor, Loader=None):
     """
     Add a constructor for the given tag.
     Constructor is a function that accepts a Loader instance
     and a node object and produces the corresponding Python object.
     """
-    Loader.add_constructor(tag, constructor)
+    if Loader == None:
+        loader.Loader.add_constructor(tag, constructor)
+        loader.FullLoader.add_constructor(tag, constructor)
+        loader.UnsafeLoader.add_constructor(tag, constructor)
+    else:
+        Loader.add_constructor(tag, constructor)
 
 def add_multi_constructor(tag_prefix, multi_constructor, Loader=Loader):
     """

--- a/lib3/yaml/__init__.py
+++ b/lib3/yaml/__init__.py
@@ -326,22 +326,32 @@ def add_path_resolver(tag, path, kind=None, Loader=Loader, Dumper=Dumper):
     Loader.add_path_resolver(tag, path, kind)
     Dumper.add_path_resolver(tag, path, kind)
 
-def add_constructor(tag, constructor, Loader=Loader):
+def add_constructor(tag, constructor, Loader=None):
     """
     Add a constructor for the given tag.
     Constructor is a function that accepts a Loader instance
     and a node object and produces the corresponding Python object.
     """
-    Loader.add_constructor(tag, constructor)
+    if Loader == None:
+        loader.Loader.add_constructor(tag, constructor)
+        loader.FullLoader.add_constructor(tag, constructor)
+        loader.UnsafeLoader.add_constructor(tag, constructor)
+    else:
+        Loader.add_constructor(tag, constructor)
 
-def add_multi_constructor(tag_prefix, multi_constructor, Loader=Loader):
+def add_multi_constructor(tag_prefix, multi_constructor, Loader=None):
     """
     Add a multi-constructor for the given tag prefix.
     Multi-constructor is called for a node if its tag starts with tag_prefix.
     Multi-constructor accepts a Loader instance, a tag suffix,
     and a node object and produces the corresponding Python object.
     """
-    Loader.add_multi_constructor(tag_prefix, multi_constructor)
+    if Loader == None:
+        loader.Loader.add_multi_constructor(tag_prefix, multi_constructor)
+        loader.FullLoader.add_multi_constructor(tag_prefix, multi_constructor)
+        loader.UnsafeLoader.add_multi_constructor(tag_prefix, multi_constructor)
+    else:
+        Loader.add_multi_constructor(tag_prefix, multi_constructor)
 
 def add_representer(data_type, representer, Dumper=Dumper):
     """


### PR DESCRIPTION
If the Loader parameter is not given, add constructor to
all three loaders.

This is an alternative to #274, consistent with @ingydotnet's PR
for `YAMLObject` #279

