### PR TITLE
Fix for Python 3.10

### DIFF
--- a/tests/lib/test_build.py
+++ b/tests/lib/test_build.py
@@ -2,7 +2,7 @@
 if __name__ == '__main__':
     import sys, os, distutils.util
     build_lib = 'build/lib'
-    build_lib_ext = os.path.join('build', 'lib.%s-%s' % (distutils.util.get_platform(), sys.version[0:3]))
+    build_lib_ext = os.path.join('build', 'lib.{}-{}.{}'.format(distutils.util.get_platform(), *sys.version_info))
     sys.path.insert(0, build_lib)
     sys.path.insert(0, build_lib_ext)
     import test_yaml, test_appliance

--- a/tests/lib/test_build_ext.py
+++ b/tests/lib/test_build_ext.py
@@ -3,7 +3,7 @@
 if __name__ == '__main__':
     import sys, os, distutils.util
     build_lib = 'build/lib'
-    build_lib_ext = os.path.join('build', 'lib.%s-%s' % (distutils.util.get_platform(), sys.version[0:3]))
+    build_lib_ext = os.path.join('build', 'lib.{}-{}.{}'.format(distutils.util.get_platform(), *sys.version_info))
     sys.path.insert(0, build_lib)
     sys.path.insert(0, build_lib_ext)
     import test_yaml_ext, test_appliance

--- a/tests/lib3/test_build.py
+++ b/tests/lib3/test_build.py
@@ -2,7 +2,7 @@
 if __name__ == '__main__':
     import sys, os, distutils.util
     build_lib = 'build/lib'
-    build_lib_ext = os.path.join('build', 'lib.%s-%s' % (distutils.util.get_platform(), sys.version[0:3]))
+    build_lib_ext = os.path.join('build', 'lib.{}-{}.{}'.format(distutils.util.get_platform(), *sys.version_info))
     sys.path.insert(0, build_lib)
     sys.path.insert(0, build_lib_ext)
     import test_yaml, test_appliance

--- a/tests/lib3/test_build_ext.py
+++ b/tests/lib3/test_build_ext.py
@@ -3,7 +3,7 @@
 if __name__ == '__main__':
     import sys, os, distutils.util
     build_lib = 'build/lib'
-    build_lib_ext = os.path.join('build', 'lib.%s-%s' % (distutils.util.get_platform(), sys.version[0:3]))
+    build_lib_ext = os.path.join('build', 'lib.{}-{}.{}'.format(distutils.util.get_platform(), *sys.version_info))
     sys.path.insert(0, build_lib)
     sys.path.insert(0, build_lib_ext)
     import test_yaml_ext, test_appliance


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 (when Python 3.9 reaches beta)](https://www.python.org/dev/peps/pep-0596/#schedule).

There's some places in the codebase that slice the `sys.version` string, assuming the string is 3 characters long. This will break on Python 3.10:

```python
>>> import sys
>>> sys.version
'3.7.4 (default, Jul  9 2019, 18:13:23) \n[Clang 10.0.1 (clang-1001.0.46.4)]'
>>> sys.version[0:3]
'3.7'
>>> v310 = '3.10.4 (default, Jul  9 2019, 18:13:23) \n[Clang 10.0.1 (clang-1001.0.46.4)]'
>>> v310[0:3]
'3.1'
```

Instead use `sys.version_info`:

```python
>>> '{}.{}'.format(*sys.version_info)
'3.7'
>>> # Will return '3.10' on Python 3.10
```

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./tests/lib3/test_build.py:5:89: YTT101: `sys.version[:...]` referenced (python3.10), use `sys.version_info`
./tests/lib3/test_build_ext.py:6:89: YTT101: `sys.version[:...]` referenced (python3.10), use `sys.version_info`
./tests/lib/test_build.py:5:89: YTT101: `sys.version[:...]` referenced (python3.10), use `sys.version_info`
./tests/lib/test_build_ext.py:6:89: YTT101: `sys.version[:...]` referenced (python3.10), use `sys.version_info`
```
