### PR TITLE
Add pyproject.toml file to specify the requirements to build PyYaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.


### PR DESCRIPTION
Using [PEP-518](https://www.python.org/dev/peps/pep-0518/) we can specify that `setuptools` and `wheel` be installed. This fixes an issue that can occur if someone has a python environment without `wheel`.