### PR TITLE
Test with libyaml 0.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   cd /tmp
   && git clone https://github.com/yaml/libyaml.git libyaml
   && cd libyaml
-  && git reset --hard 0.2.2
+  && git reset --hard 0.2.4
   && ./bootstrap
   && ./configure
   && make


### PR DESCRIPTION
libyaml 0.2.2 tests are currently failing:
https://travis-ci.org/github/yaml/pyyaml/jobs/689453153#L1145

Maybe because the wrong testsuite commit gets checked out.

Edit: `.appveyor.yml` should also be updated

Edit: I fixed the libyaml tests with this: https://github.com/yaml/libyaml/commit/a718a893542e7cf9ab8862d2ef8c43d33644cc8d

If you plan a 5.3.2 bugfix release, this PR should be merged *after* that.