### PR TITLE
Ignore python_requires when installing with distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ except ImportError:
 
 # on Windows, disable wheel generation warning noise
 windows_ignore_warnings = [
-"Unknown distribution option: 'python_requires'",
 "Config variable 'Py_DEBUG' is unset",
 "Config variable 'WITH_PYMALLOC' is unset",
 "Config variable 'Py_UNICODE_SIZE' is unset",
@@ -109,6 +108,7 @@ if platform.system() == 'Windows':
 class Distribution(_Distribution):
 
     def __init__(self, attrs=None):
+        attrs.pop('python_requires', None)
         _Distribution.__init__(self, attrs)
         if not self.ext_modules:
             return


### PR DESCRIPTION
When using `python setup.py <command>`, distutils.dist.Distribution
does not recognize python_requires (unlike setuptools) and will
issue an obnoxious warning that doesn't actually tell the user
that their Python version is not supported.

Note that this (might not be) the case with pip since it replaces
distutils with setuptools, which does support it.

The other possible solution would be to parse python_requires,
but that requires a lot of work (see pip/_internals/utils/packaging.py)
and is an example of the reason setuptools was made in the first place.