### PR TITLE
Fix get_single_data when not used in stream start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ _pycache_/*
 # local IDE state
 /.idea/*
 
+# tox artifacts
+.tox/
+*.egg-info/

--- a/lib/yaml/composer.py
+++ b/lib/yaml/composer.py
@@ -28,7 +28,8 @@ class Composer(object):
 
     def get_single_node(self):
         # Drop the STREAM-START event.
-        self.get_event()
+        if self.check_event(StreamStartEvent):
+            self.get_event()
 
         # Compose a document if the stream is not empty.
         document = None

--- a/lib3/yaml/composer.py
+++ b/lib3/yaml/composer.py
@@ -28,7 +28,8 @@ class Composer:
 
     def get_single_node(self):
         # Drop the STREAM-START event.
-        self.get_event()
+        if self.check_event(StreamStartEvent):
+            self.get_event()
 
         # Compose a document if the stream is not empty.
         document = None


### PR DESCRIPTION
Sometimes I need to read a few documents from a stream, and I know that a specific document should be the last one.
It would be nice to use `Loader.get_single_data` for the last document, but it only works on stream start. This happens because `get_single_data` assumes it is called on stream start and consumes an event, which is actually the document start if we are not in the beginning of the stream.

Before this fix:
```python
l = yaml.Loader('a\n---\nb')
l.get_data() # 'a'
l.get_single_data() # AttributeError: 'DocumentEndEvent' object has no attribute 'anchor'
```
```python
l = yaml.Loader('a\n---\nb\n---\nc')
l.get_data() # 'a'
l.get_single_data() # AttributeError: 'DocumentEndEvent' object has no attribute 'anchor'
```
After this fix:
```python
l = yaml.Loader('a\n---\nb')
l.get_data() # 'a'
l.get_single_data() # 'b'
```
```python
l = yaml.Loader('a\n---\nb\n---\nc')
l.get_data() # 'a'
l.get_single_data() # ComposerError: expected a single document in the stream
```