### PR TITLE
Add ppc64le jobs to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,15 @@ matrix:
     - python: 3.8-dev
       arch: arm64
       env: TOXENV=py38
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=py38
+    - python: 3.8-dev
+      arch: ppc64le
+      env: TOXENV=py38
     - python: pypy
       env: TOXENV=pypy
 


### PR DESCRIPTION
As with ARM64 (yaml#366, commit d0d660d), Travis CI supports ppc64le ("Power") now, so it would be good to test there too.

I've just mimicked the jobs that ARM64 does, I think that provides decent coverage without bloating the test matrix too much.

If any issues come up with the Power build in future, feel free to tag me in and I'll have a look - I have access to Power systems at work.