### PR TITLE
Revert "Improve RepresenterError creation"

### DIFF
--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -249,7 +249,7 @@ class SafeRepresenter(BaseRepresenter):
         return self.represent_mapping(tag, state, flow_style=flow_style)
 
     def represent_undefined(self, data):
-        raise RepresenterError("cannot represent an object", data)
+        raise RepresenterError("cannot represent an object: %s" % data)
 
 SafeRepresenter.add_representer(type(None),
         SafeRepresenter.represent_none)
@@ -414,7 +414,7 @@ class Representer(SafeRepresenter):
         elif hasattr(data, '__reduce__'):
             reduce = data.__reduce__()
         else:
-            raise RepresenterError("cannot represent an object", data)
+            raise RepresenterError("cannot represent object: %r" % data)
         reduce = (list(reduce)+[None]*5)[:5]
         function, args, state, listitems, dictitems = reduce
         args = list(args)

--- a/lib3/yaml/representer.py
+++ b/lib3/yaml/representer.py
@@ -228,7 +228,7 @@ class SafeRepresenter(BaseRepresenter):
         return self.represent_mapping(tag, state, flow_style=flow_style)
 
     def represent_undefined(self, data):
-        raise RepresenterError("cannot represent an object", data)
+        raise RepresenterError("cannot represent an object: %s" % data)
 
 SafeRepresenter.add_representer(type(None),
         SafeRepresenter.represent_none)
@@ -318,7 +318,7 @@ class Representer(SafeRepresenter):
         elif hasattr(data, '__reduce__'):
             reduce = data.__reduce__()
         else:
-            raise RepresenterError("cannot represent an object", data)
+            raise RepresenterError("cannot represent object: %r" % data)
         reduce = (list(reduce)+[None]*5)[:5]
         function, args, state, listitems, dictitems = reduce
         args = list(args)


### PR DESCRIPTION
Obejcts like AnsibleUndefined can't be converted to string
implicitly and this breaks ansible-lint.

This reverts commit ef744d8609f47e8b70ce007ecfe6595d3c367174.