### PR TITLE
Emit the correct indentation of sequence

### DIFF
--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -384,7 +384,7 @@ class Emitter(object):
             self.state = self.states.pop()
         else:
             self.write_indent()
-            self.write_indicator(u'-', True, indention=True)
+            self.write_indicator(u'-', True, indention=True, is_sequence=True)
             self.states.append(self.expect_block_sequence_item)
             self.expect_node(sequence=True)
 
@@ -805,9 +805,12 @@ class Emitter(object):
         self.flush_stream()
 
     def write_indicator(self, indicator, need_whitespace,
-            whitespace=False, indention=False):
+            whitespace=False, indention=False, is_sequence=False):
         if self.whitespace or not need_whitespace:
-            data = indicator
+            if is_sequence:
+                data = u' '*(self.best_indent-2)+indicator
+            else:
+                data = indicator
         else:
             data = u' '+indicator
         self.whitespace = whitespace

--- a/lib3/yaml/emitter.py
+++ b/lib3/yaml/emitter.py
@@ -379,7 +379,7 @@ class Emitter:
             self.state = self.states.pop()
         else:
             self.write_indent()
-            self.write_indicator('-', True, indention=True)
+            self.write_indicator('-', True, indention=True, is_sequence=True)
             self.states.append(self.expect_block_sequence_item)
             self.expect_node(sequence=True)
 
@@ -798,9 +798,12 @@ class Emitter:
         self.flush_stream()
 
     def write_indicator(self, indicator, need_whitespace,
-            whitespace=False, indention=False):
+            whitespace=False, indention=False, is_sequence=False):
         if self.whitespace or not need_whitespace:
-            data = indicator
+            if is_sequence:
+                data = ' '*(self.best_indent-2)+indicator
+            else:
+                data = indicator
         else:
             data = ' '+indicator
         self.whitespace = whitespace


### PR DESCRIPTION

Modify the output format of Custom indent in sequence by adding the `is_qequence` parameter in `write_indicator()`.
Refer to #234, The test case is:
```yaml
doc = """
%TAG !E! !SSSSS
---
- hosts: localhost
  vars:
    yaml:
      single_attr: value1
      list_of_dict_attr:
        - attr1: value1
          attr2: value2
          attr3:
            - item1
            - item2
  tasks:
    - debug: msg="{{ yaml | to_nice_yaml }}"
- 
  - aaa
  - ccc
...
```
the result is shown below:
> print(yaml.dump(data, indent=6, allow_unicode=True, default_flow_style=False))
```yaml
    - hosts: localhost
      tasks:
          - debug: msg="{{ yaml | to_nice_yaml }}"
      vars:
            yaml:
                  list_of_dict_attr:
                      - attr1: value1
                        attr2: value2
                        attr3:
                            - item1
                            - item2
                  single_attr: value1
    -     - aaa
          - ccc
```
> print(yaml.dump(data, indent=3, allow_unicode=True, default_flow_style=False))
```yaml
 - hosts: localhost
   tasks:
    - debug: msg="{{ yaml | to_nice_yaml }}"
   vars:
      yaml:
         list_of_dict_attr:
          - attr1: value1
            attr2: value2
            attr3:
             - item1
             - item2
         single_attr: value1
 -  - aaa
    - ccc
```

In brief, This output format is more consistent with spec. 

Do I need to add the testcases in PR? @perlpunk 