### PR TITLE
Add python 3.9 builds (#446)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,6 @@
 # TODO: update this from inside the build to use branch current version
 version: '{build}'
 
-image:
-- Visual Studio 2015
-
 #cache:
 #- 'C:\Python38\'
 #- 'C:\Python38-x64'
@@ -13,17 +10,32 @@ environment:
   libyaml_refspec: 0.2.2
   PYYAML_TEST_GROUP: all
 
-#  matrix:
-#    - PYTHON_VER: Python27
-#    - PYTHON_VER: Python27-x64
-#    - PYTHON_VER: Python35
-#    - PYTHON_VER: Python35-x64
-#    - PYTHON_VER: Python36
-#    - PYTHON_VER: Python36-x64
-#    - PYTHON_VER: Python37
-#    - PYTHON_VER: Python37-x64
-#    - PYTHON_VER: Python38
-#    - PYTHON_VER: Python38-x64
+
+  matrix:
+    - PYTHON_VER: Python27
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python27-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python35
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python35-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python36
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python36-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python37
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python37-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python38
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python38-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python39
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - PYTHON_VER: Python39-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 #init:
 #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       env: TOXENV=py38
     - python: 3.8-dev
       env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: 3.7
       arch: arm64
       env: TOXENV=py37
@@ -31,6 +33,9 @@ matrix:
     - python: 3.8-dev
       arch: arm64
       env: TOXENV=py38
+    - python: 3.9
+      arch: arm64
+      env: TOXENV=py39
     - python: pypy
       env: TOXENV=pypy
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py35,py36,py37,py38
+envlist = py27,pypy,py35,py36,py37,py38,py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Declare support for python 3.9 in setup.py

Adds 3.9 jobs to Travis CI (for AMD64 and Arm64)

For Windows Builds on AppVeyor:
* Have to use the Visual Studio 2019 image to have python 3.9, leave the
  rest of the builds using the Visual Studio 2015 image still.
* Using different images for different pythons requires using the build
  matrix, so we have multiple build jobs instead of one long build job
  which builds all flavours of wheel, so corresponding changes to the
  appveyor powershell were made to suppor that.
* Only patch Visual Studio 2008 (9.0) if it's there. It isn't there in
  AppVeyor's VS2019 image, which we have to use for python 3.9, and
  while these patching lines weren't causing the build to fail, they
  were producing unnecessary stderr noise in the build output.
* Stop warning about pip script location not on path. This was already
  happening for python 3 builds, so not new for 3.9. But the stderr
  noise was distracting so fixed here.