### PR TITLE
Drop Python 2.7 support.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,7 +211,6 @@ jobs:
         arch:
         - x86_64
         python_tag:
-        - cp27*
         - cp36*
         - cp37*
         - cp38*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,6 @@ jobs:
         python_tag:
         # NB manylinux >=2014 containers don't have Python 2.7, so we have to
         # use exclude to skip it.
-        - cp27-cp27mu
         - cp36-cp36m
         - cp37-cp37m
         - cp38-cp38

--- a/packaging/build/appveyor.ps1
+++ b/packaging/build/appveyor.ps1
@@ -117,8 +117,6 @@ Function Upload-Artifacts() {
 Bootstrap
 
 $pythons = @(
-"C:\Python27"
-"C:\Python27-x64"
 "C:\Python36"
 "C:\Python36-x64"
 "C:\Python37"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py35,py36,py37,py38,py39
+envlist = pypy,py35,py36,py37,py38,py39
 
 [testenv]
 deps =


### PR DESCRIPTION
With PyYAML 5.4 released as of recently, we could resolve https://github.com/yaml/pyyaml/issues/476 if we wanted.