### PR TITLE
Fix yaml11 float resolver for '.'

### DIFF
--- a/lib/yaml/resolver.py
+++ b/lib/yaml/resolver.py
@@ -177,7 +177,7 @@ Resolver.add_implicit_resolver(
 Resolver.add_implicit_resolver(
         'tag:yaml.org,2002:float',
         re.compile(r'''^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+][0-9]+)?
-                    |\.[0-9_]+(?:[eE][-+][0-9]+)?
+                    |\.[0-9][0-9_]*(?:[eE][-+][0-9]+)?
                     |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*
                     |[-+]?\.(?:inf|Inf|INF)
                     |\.(?:nan|NaN|NAN))$''', re.X),

--- a/tests/data/yaml11.schema-skip
+++ b/tests/data/yaml11.schema-skip
@@ -1,8 +1,6 @@
 load: {
   'Y': 1, 'y': 1, 'N': 1, 'n': 1,
   '!!bool Y': 1, '!!bool N': 1, '!!bool n': 1, '!!bool y': 1,
-  '._',   '!!str ._',
-  '._14', '!!str ._14'
   }
 dump: {
   '!!str N': 1, '!!str Y': 1, '!!str n': 1, '!!str y': 1,


### PR DESCRIPTION
This depends on #483.

Fixes #168 
(see also #473 )


`._` and `.` will now be loaded as strings.

The spec says that any digit is optional:
https://yaml.org/type/float.html

But we assume that this was not intended, so now at least one digit is required before and after the dot.
