### PR TITLE
Add method to construct mapping key

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -160,6 +160,20 @@ class BaseConstructor(object):
         return [self.construct_object(child, deep=deep)
                 for child in node.value]
 
+    def construct_mapping_key(self, key, mapping):
+        """
+        This method simply returns key by default, but it can be overridden to
+        check that the key is not a duplicate:
+
+        def construct_mapping_key(self, key, mapping):
+            if key is in mapping:
+                raise ValueError("The {key} key is already in {mapping}".format(
+                    key=key,
+                    mapping=mapping))
+            return key
+        """
+        return key
+
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,
@@ -173,6 +187,7 @@ class BaseConstructor(object):
             except TypeError, exc:
                 raise ConstructorError("while constructing a mapping", node.start_mark,
                         "found unacceptable key (%s)" % exc, key_node.start_mark)
+            key = self.construct_mapping_key(key, mapping)
             value = self.construct_object(value_node, deep=deep)
             mapping[key] = value
         return mapping

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -129,6 +129,18 @@ class BaseConstructor:
         return [self.construct_object(child, deep=deep)
                 for child in node.value]
 
+    def construct_mapping_key(self, key, mapping):
+        """
+        This method simply returns key by default, but it can be overridden to
+        check that the key is not a duplicate:
+
+        def construct_mapping_key(self, key, mapping):
+            if key is in mapping:
+                raise ValueError(f"The {key} key is already in {mapping}")
+            return key
+        """
+        return key
+
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,
@@ -140,6 +152,7 @@ class BaseConstructor:
             if not isinstance(key, collections.abc.Hashable):
                 raise ConstructorError("while constructing a mapping", node.start_mark,
                         "found unhashable key", key_node.start_mark)
+            key = self.construct_mapping_key(key, mapping)
             value = self.construct_object(value_node, deep=deep)
             mapping[key] = value
         return mapping

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -317,6 +317,44 @@ def test_timezone_copy(verbose=False):
 
 test_timezone_copy.unittest = []
 
+
+def test_constructor_default_mapping():
+    test_mapping = '''
+    ---
+    foo: bar
+    foo: baz
+    '''
+    data = yaml.load(test_mapping)
+
+    self.assertIsSubclass(data, dict)
+    self.assertIn('foo', data)
+    # This test isn't supposed to test which value wins, it is only supposed to
+    # test that the default mapping constructor allows duplicate keys to be
+    # specified. One of the two values will win out, but we don't care which
+    # one. We allow for either, that way if the behavior changes in the future
+    # it doesn't break this unrelated test.
+    self.assertIn(data['foo'], ['bar', 'baz'])
+
+
+def test_constructor_mapping_with_unique_keys():
+    class UniqueKeyLoader(yaml.loader.Loader):
+        def construct_mapping_key(self, key, mapping):
+            if key in mapping:
+                raise ValueError("The {key} key is already in {mapping}".format(
+                    key=key,
+                    mapping=mapping))
+            return key
+
+    test_mapping = '''
+    ---
+    foo: bar
+    foo: baz
+    '''
+
+    with self.assertRaises(ValueError):
+        yaml.load(test_mapping)
+
+
 if __name__ == '__main__':
     import sys, test_constructor
     sys.modules['test_constructor'] = sys.modules['__main__']

--- a/tests/lib3/test_appliance.py
+++ b/tests/lib3/test_appliance.py
@@ -123,6 +123,7 @@ def run(collections, args=None):
     for function in test_functions:
         if include_functions and function.__name__ not in include_functions:
             continue
+        print(f'\n{function.__name__}')
         if function.unittest:
             for base, exts in test_filenames:
                 if include_filenames and base not in include_filenames:


### PR DESCRIPTION
This PR makes it much easier to generate a safe loader (or a normal loader) that disallows duplicate keys in mappings.

This follows a few points of the [Zen of Python](https://www.python.org/dev/peps/pep-0020/):

* Beautiful is better than ugly.
* Simple is better than complex.
* If the implementation is easy to explain, it may be a good idea.

Before (which I'm pretty sure mutates global state):

```python
data = '''
---
foo: bar
foo: qux
'''

def no_duplicates_constructor(loader, node, deep=False):
    """Check for duplicate keys."""

    mapping = {}
    for key_node, value_node in node.value:
        key = loader.construct_object(key_node, deep=deep)
        value = loader.construct_object(value_node, deep=deep)
        if key in mapping:
            raise ConstructorError("while constructing a mapping", node.start_mark,
                                   "found duplicate key (%s)" % key, key_node.start_mark)
        mapping[key] = value

    return loader.construct_mapping(node, deep)

yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicates_constructor, yaml.SafeLoader)

yaml.safe_load(data)
```

After (does not mutate global state):

```python
import yaml

data = '''
---
foo: bar
foo: qux
'''

class SafeUniqueKeyLoader(yaml.loader.SafeLoader):
    def construct_mapping_key(self, key, mapping):
        if key in mapping:
            raise ValueError(f"The '{key}' key already exists in {mapping}")

yaml.load(data, SafeUniqueKeyLoader)
```

IMO, the second one is a lot easier to explain to somebody who is new to PyYAML.

A few points for your consideration:

* I have intentionally omitted any parsing data from the parameters to `construct_mapping_key` and subsequently from the raised exception in the example method, because it isn't technically a parsing error, and it should be obvious from the exception message which dictionary/object the duplicate key appeared in. I have an alternative PR with a slightly different implementation incoming.
* I have no idea where to document this, so the quick docstrings are the only documentation I have made for this. I'm happy to write better and more thorough documentation if you point me to it.