### PR TITLE
Add method to check mapping key

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -160,6 +160,22 @@ class BaseConstructor(object):
         return [self.construct_object(child, deep=deep)
                 for child in node.value]
 
+    def check_mapping_key(self, node, key_node, key, mapping):
+        """
+        This method implements checks for mapping keys. By default it checks
+        that the key is hashable. It can be overridden to implement additional
+        checks, such as uniqueness checks.
+
+        def check_mapping_key(self, node, key_node, key, mapping):
+            super().check_mapping_key(node, key_node, key, mapping)
+            if key in mapping:
+                raise ConstructorError("while constructing a mapping", node.start_mark,
+                    "found duplicate key", key_node, start_mark)
+        """
+        if not isinstance(key, collections.abc.Hashable):
+            raise ConstructorError("while constructing a mapping", node.start_mark,
+                    "found unhashable key", key_node.start_mark)
+
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,

--- a/lib3/yaml/constructor.py
+++ b/lib3/yaml/constructor.py
@@ -129,6 +129,22 @@ class BaseConstructor:
         return [self.construct_object(child, deep=deep)
                 for child in node.value]
 
+    def check_mapping_key(self, node, key_node, key, mapping):
+        """
+        This method implements checks for mapping keys. By default it checks
+        that the key is hashable. It can be overridden to implement additional
+        checks, such as uniqueness checks.
+
+        def check_mapping_key(self, node, key_node, key, mapping):
+            super().check_mapping_key(node, key_node, key, mapping)
+            if key in mapping:
+                raise ConstructorError("while constructing a mapping", node.start_mark,
+                    "found duplicate key", key_node, start_mark)
+        """
+        if not isinstance(key, collections.abc.Hashable):
+            raise ConstructorError("while constructing a mapping", node.start_mark,
+                    "found unhashable key", key_node.start_mark)
+
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,
@@ -137,9 +153,7 @@ class BaseConstructor:
         mapping = {}
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
-            if not isinstance(key, collections.abc.Hashable):
-                raise ConstructorError("while constructing a mapping", node.start_mark,
-                        "found unhashable key", key_node.start_mark)
+            self.check_mapping_key(node, key_node, key, mapping)
             value = self.construct_object(value_node, deep=deep)
             mapping[key] = value
         return mapping

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -317,6 +317,43 @@ def test_timezone_copy(verbose=False):
 
 test_timezone_copy.unittest = []
 
+
+def test_constructor_default_mapping():
+    test_mapping = '''
+    ---
+    foo: bar
+    foo: baz
+    '''
+    data = yaml.load(test_mapping)
+
+    self.assertIsSubclass(data, dict)
+    self.assertIn('foo', data)
+    # This test isn't supposed to test which value wins, it is only supposed to
+    # test that the default mapping constructor allows duplicate keys to be
+    # specified. One of the two values will win out, but we don't care which
+    # one. We allow for either, that way if the behavior changes in the future
+    # it doesn't break this unrelated test.
+    self.assertIn(data['foo'], ['bar', 'baz'])
+
+
+def test_constructor_mapping_with_unique_keys():
+    class UniqueKeyLoader(yaml.loader.Loader):
+        def check_mapping_key(self, node, key_node, key, mapping):
+            super().check_mapping_key(node, key_node, key, mapping)
+            if key in mapping:
+                raise ConstructorError("while constructing a mapping", node.start_mark,
+                    "found duplicate key", key_node, start_mark)
+
+    test_mapping = '''
+    ---
+    foo: bar
+    foo: baz
+    '''
+
+    with self.assertRaises(yaml.constructor.ConstructionError):
+        yaml.load(test_mapping)
+
+
 if __name__ == '__main__':
     import sys, test_constructor
     sys.modules['test_constructor'] = sys.modules['__main__']

--- a/tests/lib3/test_appliance.py
+++ b/tests/lib3/test_appliance.py
@@ -119,8 +119,12 @@ def run(collections, args=None):
     test_functions = find_test_functions(collections)
     test_filenames = find_test_filenames(DATA)
     include_functions, include_filenames, verbose = parse_arguments(args)
+    print(f'include_functions: {include_functions}')
+    print(f'include_filenames: {include_filenames}')
+    print(f'verbose: {verbose}')
     results = []
     for function in test_functions:
+        print(f'\n  function: {function.__name__}')
         if include_functions and function.__name__ not in include_functions:
             continue
         if function.unittest:


### PR DESCRIPTION
This PR makes it much easier to generate a safe loader (or a normal loader) that disallows duplicate keys in mappings.

This follows a few points of the [Zen of Python](https://www.python.org/dev/peps/pep-0020/):

* Beautiful is better than ugly.
* Simple is better than complex.
* If the implementation is easy to explain, it may be a good idea.

Before (which I'm pretty sure mutates global state):

```python
data = '''
---
foo: bar
foo: qux
'''

def no_duplicates_constructor(loader, node, deep=False):
    """Check for duplicate keys."""

    mapping = {}
    for key_node, value_node in node.value:
        key = loader.construct_object(key_node, deep=deep)
        value = loader.construct_object(value_node, deep=deep)
        if key in mapping:
            raise ConstructorError("while constructing a mapping", node.start_mark,
                                   "found duplicate key (%s)" % key, key_node.start_mark)
        mapping[key] = value

    return loader.construct_mapping(node, deep)

yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicates_constructor, yaml.SafeLoader)

yaml.safe_load(data)
```

After (does not mutate global state):

```python
import yaml

data = '''
---
foo: bar
foo: qux
'''

class SafeUniqueKeyLoader(yaml.loader.SafeLoader):
    def check_mapping_key(self, node, key_node, key, mapping):
        super().check_mapping_key(node, key_node, key, mapping)
        if key in mapping:
            raise ConstructorError("while constructing a mapping", node.start_mark,
                "found duplicate key", key_node, start_mark)

yaml.load(data, SafeUniqueKeyLoader)
```

A few points for your consideration:

* This PR is slightly more complicated, but it might enable better error messages than #502.
* I have no idea where to document this, so the quick docstrings are the only documentation I have made for this. I'm happy to write better and more thorough documentation if you point me to it.