### PR TITLE
Replace deprecated license_file wheel metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@
 #define=YAML_DECLARE_STATIC
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
The wheel 0.32.1 release deprecated the license_file metadata option
in favor of license_files, and started raising a DeprecationWarning
exception for its use.

When installing PyYAML on platforms with no available prebuilt
wheel, such as testing with Python 3.10 beta releases, treating
warnings as errors causes versions after the addition of PR #102 to
be skipped due to this DeprecationWarning. The end result is that
PyYAML 3.13 gets installed into the environment because it's the
newest version pip is able to install without error, but that of
course doesn't actually work with modern Python interpreters.

Replace metadata.license_file with metadata.license_files in
setup.cfg to address this problem.