### PR TITLE
Set the Cython language_level to 2

### DIFF
--- a/yaml/_yaml.pxd
+++ b/yaml/_yaml.pxd
@@ -1,3 +1,4 @@
+#cython: language_level=2
 
 cdef extern from "_yaml.h":
 


### PR DESCRIPTION
As of Cython 0.29 there is a language_level keyword argument
(accepting values of 2, 3, or 3str), and Cython raises
FutureWarning indicating it's defaulting to 2 but will eventually
change its default in a later release. This FutureWarning exception
is caught when building wheels from sdist, such as may happen when
testing software which depends on PyYAML with Python 3.10 beta
releases for which no prebuilt wheels are published, and if
PYTHONWARNINGS is set to error this causes pip to fall back on
installing an older version of PyYAML (currently 5.3.1).

Set the language_level explicitly in yaml/_yaml.pxd to the current
default value in order to address this condition, and a future
commit can change it to the planned 3str default when that makes
sense for the project. This helps projects depending on PyYAML not
to need to add ignore::FutureWarning:Cython.Compiler.Main to their
PYTHONWARNINGS (the exception message itself can't be matched
because it contains a comma, which is the PYTHONWARNINGS delimiter).