### PR TITLE
Remove py35 from tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py35,py36,py37,py38,py39
+envlist = py27,pypy,py36,py37,py38,py39
 
 [testenv]
 deps =


### PR DESCRIPTION
It looks like 3.5 isn't supported, but it's in the tox.ini envlist, which is causing tox to error.