### PR TITLE
fix: typos

### DIFF
--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -1217,7 +1217,7 @@ class Scanner(object):
                     for k in range(length):
                         if self.peek(k) not in u'0123456789ABCDEFabcdef':
                             raise ScannerError("while scanning a double-quoted scalar", start_mark,
-                                    "expected escape sequence of %d hexdecimal numbers, but found %r" %
+                                    "expected escape sequence of %d hexadecimal numbers, but found %r" %
                                         (length, self.peek(k).encode('utf-8')), self.get_mark())
                     code = int(self.prefix(length), 16)
                     chunks.append(unichr(code))
@@ -1412,7 +1412,7 @@ class Scanner(object):
             for k in range(2):
                 if self.peek(k) not in u'0123456789ABCDEFabcdef':
                     raise ScannerError("while scanning a %s" % name, start_mark,
-                            "expected URI escape sequence of 2 hexdecimal numbers, but found %r" %
+                            "expected URI escape sequence of 2 hexadecimal numbers, but found %r" %
                                 (self.peek(k).encode('utf-8')), self.get_mark())
             bytes.append(chr(int(self.prefix(2), 16)))
             self.forward(2)

--- a/lib3/yaml/scanner.py
+++ b/lib3/yaml/scanner.py
@@ -1211,7 +1211,7 @@ class Scanner:
                     for k in range(length):
                         if self.peek(k) not in '0123456789ABCDEFabcdef':
                             raise ScannerError("while scanning a double-quoted scalar", start_mark,
-                                    "expected escape sequence of %d hexdecimal numbers, but found %r" %
+                                    "expected escape sequence of %d hexadecimal numbers, but found %r" %
                                         (length, self.peek(k)), self.get_mark())
                     code = int(self.prefix(length), 16)
                     chunks.append(chr(code))
@@ -1403,7 +1403,7 @@ class Scanner:
             for k in range(2):
                 if self.peek(k) not in '0123456789ABCDEFabcdef':
                     raise ScannerError("while scanning a %s" % name, start_mark,
-                            "expected URI escape sequence of 2 hexdecimal numbers, but found %r"
+                            "expected URI escape sequence of 2 hexadecimal numbers, but found %r"
                             % self.peek(k), self.get_mark())
             codes.append(int(self.prefix(2), 16))
             self.forward(2)


### PR DESCRIPTION
This fixes typos related to the word "hexadecimal"

I did notice also you are hardcoding the hex digits, I didn't include it in this scope, but you can simply use `string.hexdigits` (see https://docs.python.org/3/library/string.html#string.hexdigits for Python 3 and https://docs.python.org/2/library/string.html#string.hexdigits for Python 2) as a constant instead (this also applies to other constant values.