### PR TITLE
Convert README to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,47 @@
-PyYAML - The next generation YAML parser and emitter for Python.
+PyYAML
+======
 
-To install, type 'python setup.py install'.
+The next generation YAML parser and emitter for Python.
+
+To install, type `python setup.py install`.
 
 By default, the setup.py script checks whether LibYAML is installed
 and if so, builds and installs LibYAML bindings.  To skip the check
-and force installation of LibYAML bindings, use the option '--with-libyaml':
-'python setup.py --with-libyaml install'.  To disable the check and
-skip building and installing LibYAML bindings, use '--without-libyaml':
-'python setup.py --without-libyaml install'.
+and force installation of LibYAML bindings, use the option `--with-libyaml`:
+`python setup.py --with-libyaml install`.  To disable the check and
+skip building and installing LibYAML bindings, use `--without-libyaml`:
+`python setup.py --without-libyaml install`.
 
 When LibYAML bindings are installed, you may use fast LibYAML-based
 parser and emitter as follows:
 
-    >>> yaml.load(stream, Loader=yaml.CLoader)
-    >>> yaml.dump(data, Dumper=yaml.CDumper)
+```python
+>>> yaml.load(stream, Loader=yaml.CLoader)
+>>> yaml.dump(data, Dumper=yaml.CDumper)
+```
 
 If you don't trust the input stream, you should use:
 
-    >>> yaml.safe_load(stream)
+```python
+>>> yaml.safe_load(stream)
+```
 
 PyYAML includes a comprehensive test suite.  To run the tests,
-type 'python setup.py test'.
+type `python setup.py test`.
 
 For more information, check the PyYAML homepage:
-'https://github.com/yaml/pyyaml'.
+<https://github.com/yaml/pyyaml>.
 
 For PyYAML tutorial and reference, see:
-'http://pyyaml.org/wiki/PyYAMLDocumentation'.
+<http://pyyaml.org/wiki/PyYAMLDocumentation>.
 
 Discuss PyYAML with the maintainers in IRC #pyyaml irc.freenode.net.
 
 You may also use the YAML-Core mailing list:
-'http://lists.sourceforge.net/lists/listinfo/yaml-core'.
+<http://lists.sourceforge.net/lists/listinfo/yaml-core>.
 
 Submit bug reports and feature requests to the PyYAML bug tracker:
-'https://github.com/yaml/pyyaml/issues'.
+<https://github.com/yaml/pyyaml/issues>.
 
 The PyYAML module was written by Kirill Simonov <xi@resolvent.net>.
 It is currently maintained by the YAML and Python communities.


### PR DESCRIPTION
Supersedes #327, #467.

Should be identical to #467, except:

- Pointing at the release/6.0 branch.
- Formatting the title and tagline as @ingydotnet suggested.
- Using fenced code blocks.