### PR TITLE
Fix issue with representing Enum types

### DIFF
--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -369,7 +369,7 @@ Representer.add_representer(complex,
 Representer.add_representer(tuple,
         Representer.represent_tuple)
 
-Representer.add_representer(type,
+Representer.add_multi_representer(type,
         Representer.represent_name)
 
 Representer.add_representer(collections.OrderedDict,

--- a/tests/data/construct-python-name-module.code
+++ b/tests/data/construct-python-name-module.code
@@ -1,1 +1,1 @@
-[str, yaml.Loader, yaml.dump, abs, yaml.tokens]
+[str, yaml.Loader, yaml.dump, abs, yaml.tokens, signal.Handlers]

--- a/tests/data/construct-python-name-module.data
+++ b/tests/data/construct-python-name-module.data
@@ -3,3 +3,4 @@
 - !!python/name:yaml.dump
 - !!python/name:abs
 - !!python/module:yaml.tokens
+- !!python/name:signal.Handlers

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -5,6 +5,9 @@ import pprint
 import datetime
 import yaml.tokens
 
+# Import any packages here that need to be referenced in .code files.
+import signal
+
 def execute(code):
     global value
     exec(code)


### PR DESCRIPTION
Fix #511.

There's a kludge in the test. We need to refer to an enum in global scope, so I import the `signal` module and refer to `signal.Handlers`. I'm sure there's a better way to do this.