### PR TITLE
Use with statements to eliminate ResourceWarnings

### DIFF
--- a/tests/lib/test_appliance.py
+++ b/tests/lib/test_appliance.py
@@ -103,7 +103,8 @@ def display(results, verbose):
         for filename in filenames:
             sys.stdout.write('-'*75+'\n')
             sys.stdout.write('%s:\n' % filename)
-            data = open(filename, 'r', errors='replace').read()
+            with open(filename, 'r', errors='replace') as file:
+                data = file.read()
             sys.stdout.write(data)
             if data and data[-1] != '\n':
                 sys.stdout.write('\n')

--- a/tests/lib/test_canonical.py
+++ b/tests/lib/test_canonical.py
@@ -2,7 +2,8 @@
 import yaml, canonical
 
 def test_canonical_scanner(canonical_filename, verbose=False):
-    data = open(canonical_filename, 'rb').read()
+    with open(canonical_filename, 'rb') as file:
+        data = file.read()
     tokens = list(yaml.canonical_scan(data))
     assert tokens, tokens
     if verbose:
@@ -12,7 +13,8 @@ def test_canonical_scanner(canonical_filename, verbose=False):
 test_canonical_scanner.unittest = ['.canonical']
 
 def test_canonical_parser(canonical_filename, verbose=False):
-    data = open(canonical_filename, 'rb').read()
+    with open(canonical_filename, 'rb') as file:
+        data = file.read()
     events = list(yaml.canonical_parse(data))
     assert events, events
     if verbose:
@@ -22,7 +24,8 @@ def test_canonical_parser(canonical_filename, verbose=False):
 test_canonical_parser.unittest = ['.canonical']
 
 def test_canonical_error(data_filename, canonical_filename, verbose=False):
-    data = open(data_filename, 'rb').read()
+    with open(data_filename, 'rb') as file:
+        data = file.read()
     try:
         output = list(yaml.canonical_load_all(data))
     except yaml.YAMLError as exc:

--- a/tests/lib/test_constructor.py
+++ b/tests/lib/test_constructor.py
@@ -257,10 +257,12 @@ def test_constructor_types(data_filename, code_filename, verbose=False):
     native1 = None
     native2 = None
     try:
-        native1 = list(yaml.load_all(open(data_filename, 'rb'), Loader=MyLoader))
+        with open(data_filename, 'rb') as file:
+            native1 = list(yaml.load_all(file, Loader=MyLoader))
         if len(native1) == 1:
             native1 = native1[0]
-        native2 = _load_code(open(code_filename, 'rb').read())
+        with open(code_filename, 'rb') as file:
+            native2 = _load_code(file.read())
         try:
             if native1 == native2:
                 return
@@ -284,7 +286,8 @@ test_constructor_types.unittest = ['.data', '.code']
 def test_subclass_blacklist_types(data_filename, verbose=False):
     _make_objects()
     try:
-        yaml.load(open(data_filename, 'rb').read(), MyFullLoader)
+        with open(data_filename, 'rb') as file:
+            yaml.load(file.read(), MyFullLoader)
     except yaml.YAMLError as exc:
         if verbose:
             print("%s:" % exc.__class__.__name__, exc)

--- a/tests/lib/test_emitter.py
+++ b/tests/lib/test_emitter.py
@@ -15,7 +15,8 @@ def _compare_events(events1, events2):
             assert event1.value == event2.value, (event1, event2)
 
 def test_emitter_on_data(data_filename, canonical_filename, verbose=False):
-    events = list(yaml.parse(open(data_filename, 'rb')))
+    with open(data_filename, 'rb') as file:
+        events = list(yaml.parse(file))
     output = yaml.emit(events)
     if verbose:
         print("OUTPUT:")
@@ -26,7 +27,8 @@ def test_emitter_on_data(data_filename, canonical_filename, verbose=False):
 test_emitter_on_data.unittest = ['.data', '.canonical']
 
 def test_emitter_on_canonical(canonical_filename, verbose=False):
-    events = list(yaml.parse(open(canonical_filename, 'rb')))
+    with open(canonical_filename, 'rb') as file:
+        events = list(yaml.parse(file))
     for canonical in [False, True]:
         output = yaml.emit(events, canonical=canonical)
         if verbose:
@@ -39,7 +41,8 @@ test_emitter_on_canonical.unittest = ['.canonical']
 
 def test_emitter_styles(data_filename, canonical_filename, verbose=False):
     for filename in [data_filename, canonical_filename]:
-        events = list(yaml.parse(open(filename, 'rb')))
+        with open(filename, 'rb') as file:
+            events = list(yaml.parse(file))
         for flow_style in [False, True]:
             for style in ['|', '>', '"', '\'', '']:
                 styled_events = []
@@ -86,7 +89,8 @@ class EventsLoader(yaml.Loader):
 EventsLoader.add_constructor(None, EventsLoader.construct_event)
 
 def test_emitter_events(events_filename, verbose=False):
-    events = list(yaml.load(open(events_filename, 'rb'), Loader=EventsLoader))
+    with open(events_filename, 'rb') as file:
+        events = list(yaml.load(file, Loader=EventsLoader))
     output = yaml.emit(events)
     if verbose:
         print("OUTPUT:")

--- a/tests/lib/test_errors.py
+++ b/tests/lib/test_errors.py
@@ -3,7 +3,8 @@ import yaml, test_emitter
 
 def test_loader_error(error_filename, verbose=False):
     try:
-        list(yaml.load_all(open(error_filename, 'rb'), yaml.FullLoader))
+        with open(error_filename, 'rb') as file:
+            list(yaml.load_all(file, yaml.FullLoader))
     except yaml.YAMLError as exc:
         if verbose:
             print("%s:" % exc.__class__.__name__, exc)
@@ -14,7 +15,8 @@ test_loader_error.unittest = ['.loader-error']
 
 def test_loader_error_string(error_filename, verbose=False):
     try:
-        list(yaml.load_all(open(error_filename, 'rb').read(), yaml.FullLoader))
+        with open(error_filename, 'rb') as file:
+            list(yaml.load_all(file.read(), yaml.FullLoader))
     except yaml.YAMLError as exc:
         if verbose:
             print("%s:" % exc.__class__.__name__, exc)
@@ -25,7 +27,8 @@ test_loader_error_string.unittest = ['.loader-error']
 
 def test_loader_error_single(error_filename, verbose=False):
     try:
-        yaml.load(open(error_filename, 'rb').read(), yaml.FullLoader)
+        with open(error_filename, 'rb') as file:
+            yaml.load(file.read(), yaml.FullLoader)
     except yaml.YAMLError as exc:
         if verbose:
             print("%s:" % exc.__class__.__name__, exc)
@@ -35,8 +38,8 @@ def test_loader_error_single(error_filename, verbose=False):
 test_loader_error_single.unittest = ['.single-loader-error']
 
 def test_emitter_error(error_filename, verbose=False):
-    events = list(yaml.load(open(error_filename, 'rb'),
-                    Loader=test_emitter.EventsLoader))
+    with open(error_filename, 'rb') as file:
+        events = list(yaml.load(file, Loader=test_emitter.EventsLoader))
     try:
         yaml.emit(events)
     except yaml.YAMLError as exc:
@@ -48,7 +51,8 @@ def test_emitter_error(error_filename, verbose=False):
 test_emitter_error.unittest = ['.emitter-error']
 
 def test_dumper_error(error_filename, verbose=False):
-    code = open(error_filename, 'rb').read()
+    with open(error_filename, 'rb') as file:
+        code = file.read()
     try:
         import yaml
         from io import StringIO

--- a/tests/lib/test_input_output.py
+++ b/tests/lib/test_input_output.py
@@ -3,7 +3,8 @@ import yaml
 import codecs, io, tempfile, os, os.path
 
 def test_unicode_input(unicode_filename, verbose=False):
-    data = open(unicode_filename, 'rb').read().decode('utf-8')
+    with open(unicode_filename, 'rb') as file:
+        data = file.read().decode('utf-8')
     value = ' '.join(data.split())
     output = yaml.full_load(data)
     assert output == value, (output, value)
@@ -23,7 +24,8 @@ def test_unicode_input(unicode_filename, verbose=False):
 test_unicode_input.unittest = ['.unicode']
 
 def test_unicode_input_errors(unicode_filename, verbose=False):
-    data = open(unicode_filename, 'rb').read().decode('utf-8')
+    with open(unicode_filename, 'rb') as file:
+        data = file.read().decode('utf-8')
     for input in [data.encode('utf-16-be'),
             data.encode('utf-16-le'),
             codecs.BOM_UTF8+data.encode('utf-16-be'),
@@ -47,7 +49,8 @@ def test_unicode_input_errors(unicode_filename, verbose=False):
 test_unicode_input_errors.unittest = ['.unicode']
 
 def test_unicode_output(unicode_filename, verbose=False):
-    data = open(unicode_filename, 'rb').read().decode('utf-8')
+    with open(unicode_filename, 'rb') as file:
+        data = file.read().decode('utf-8')
     value = ' '.join(data.split())
     for allow_unicode in [False, True]:
         data1 = yaml.dump(value, allow_unicode=allow_unicode)
@@ -82,7 +85,8 @@ def test_unicode_output(unicode_filename, verbose=False):
 test_unicode_output.unittest = ['.unicode']
 
 def test_file_output(unicode_filename, verbose=False):
-    data = open(unicode_filename, 'rb').read().decode('utf-8')
+    with open(unicode_filename, 'rb') as file:
+        data = file.read().decode('utf-8')
     handle, filename = tempfile.mkstemp()
     os.close(handle)
     try:
@@ -92,14 +96,14 @@ def test_file_output(unicode_filename, verbose=False):
         stream = io.BytesIO()
         yaml.dump(data, stream, encoding='utf-16-le', allow_unicode=True)
         data2 = stream.getvalue().decode('utf-16-le')[1:]
-        stream = open(filename, 'w', encoding='utf-16-le')
-        yaml.dump(data, stream, allow_unicode=True)
-        stream.close()
-        data3 = open(filename, 'r', encoding='utf-16-le').read()
-        stream = open(filename, 'wb')
-        yaml.dump(data, stream, encoding='utf-8', allow_unicode=True)
-        stream.close()
-        data4 = open(filename, 'r', encoding='utf-8').read()
+        with open(filename, 'w', encoding='utf-16-le') as stream:
+            yaml.dump(data, stream, allow_unicode=True)
+        with open(filename, 'r', encoding='utf-16-le') as file:
+            data3 = file.read()
+        with open(filename, 'wb') as stream:
+            yaml.dump(data, stream, encoding='utf-8', allow_unicode=True)
+        with open(filename, 'r', encoding='utf-8') as file:
+            data4 = file.read()
         assert data1 == data2, (data1, data2)
         assert data1 == data3, (data1, data3)
         assert data1 == data4, (data1, data4)
@@ -110,7 +114,8 @@ def test_file_output(unicode_filename, verbose=False):
 test_file_output.unittest = ['.unicode']
 
 def test_unicode_transfer(unicode_filename, verbose=False):
-    data = open(unicode_filename, 'rb').read().decode('utf-8')
+    with open(unicode_filename, 'rb') as file:
+        data = file.read().decode('utf-8')
     for encoding in [None, 'utf-8', 'utf-16-be', 'utf-16-le']:
         input = data
         if encoding is not None:

--- a/tests/lib/test_mark.py
+++ b/tests/lib/test_mark.py
@@ -2,7 +2,8 @@
 import yaml
 
 def test_marks(marks_filename, verbose=False):
-    inputs = open(marks_filename, 'r').read().split('---\n')[1:]
+    with open(marks_filename, 'r') as file:
+        inputs = file.read().split('---\n')[1:]
     for input in inputs:
         index = 0
         line = 0

--- a/tests/lib/test_multi_constructor.py
+++ b/tests/lib/test_multi_constructor.py
@@ -29,8 +29,10 @@ class Multi2(yaml.FullLoader):
     pass
 
 def test_multi_constructor(input_filename, code_filename, verbose=False):
-    input = open(input_filename, 'rb').read().decode('utf-8')
-    native = _load_code(open(code_filename, 'rb').read())
+    with open(input_filename, 'rb') as file:
+        input = file.read().decode('utf-8')
+    with open(code_filename, 'rb') as file:
+        native = _load_code(file.read())
 
     # default multi constructor for ! and !! tags
     Multi1.add_multi_constructor('!', myconstructor1)

--- a/tests/lib/test_reader.py
+++ b/tests/lib/test_reader.py
@@ -13,18 +13,22 @@ def _run_reader(data, verbose):
         raise AssertionError("expected an exception")
 
 def test_stream_error(error_filename, verbose=False):
-    _run_reader(open(error_filename, 'rb'), verbose)
-    _run_reader(open(error_filename, 'rb').read(), verbose)
+    with open(error_filename, 'rb') as file:
+        _run_reader(file, verbose)
+    with open(error_filename, 'rb') as file:
+        _run_reader(file.read(), verbose)
     for encoding in ['utf-8', 'utf-16-le', 'utf-16-be']:
         try:
-            data = open(error_filename, 'rb').read().decode(encoding)
+            with open(error_filename, 'rb') as file:
+                data = file.read().decode(encoding)
             break
         except UnicodeDecodeError:
             pass
     else:
         return
     _run_reader(data, verbose)
-    _run_reader(open(error_filename, encoding=encoding), verbose)
+    with open(error_filename, encoding=encoding) as file:
+        _run_reader(file, verbose)
 
 test_stream_error.unittest = ['.stream-error']
 

--- a/tests/lib/test_recursive.py
+++ b/tests/lib/test_recursive.py
@@ -24,7 +24,8 @@ class AnInstanceWithState(AnInstance):
 
 def test_recursive(recursive_filename, verbose=False):
     context = globals().copy()
-    exec(open(recursive_filename, 'rb').read(), context)
+    with open(recursive_filename, 'rb') as file:
+        exec(file.read(), context)
     value1 = context['value']
     output1 = None
     value2 = None

--- a/tests/lib/test_representer.py
+++ b/tests/lib/test_representer.py
@@ -7,7 +7,8 @@ def test_representer_types(code_filename, verbose=False):
     test_constructor._make_objects()
     for allow_unicode in [False, True]:
         for encoding in ['utf-8', 'utf-16-be', 'utf-16-le']:
-            native1 = test_constructor._load_code(open(code_filename, 'rb').read())
+            with open(code_filename, 'rb') as file:
+                native1 = test_constructor._load_code(file.read())
             native2 = None
             try:
                 output = yaml.dump(native1, Dumper=test_constructor.MyDumper,

--- a/tests/lib/test_resolver.py
+++ b/tests/lib/test_resolver.py
@@ -6,8 +6,10 @@ def test_implicit_resolver(data_filename, detect_filename, verbose=False):
     correct_tag = None
     node = None
     try:
-        correct_tag = open(detect_filename, 'r').read().strip()
-        node = yaml.compose(open(data_filename, 'rb'))
+        with open(detect_filename, 'r') as file:
+            correct_tag = file.read().strip()
+        with open(data_filename, 'rb') as file:
+            node = yaml.compose(file)
         assert isinstance(node, yaml.SequenceNode), node
         for scalar in node.value:
             assert isinstance(scalar, yaml.ScalarNode), scalar
@@ -58,8 +60,10 @@ def _convert_node(node):
 
 def test_path_resolver_loader(data_filename, path_filename, verbose=False):
     _make_path_loader_and_dumper()
-    nodes1 = list(yaml.compose_all(open(data_filename, 'rb').read(), Loader=MyLoader))
-    nodes2 = list(yaml.compose_all(open(path_filename, 'rb').read()))
+    with open(data_filename, 'rb') as file:
+        nodes1 = list(yaml.compose_all(file.read(), Loader=MyLoader))
+    with open(path_filename, 'rb') as file:
+        nodes2 = list(yaml.compose_all(file.read()))
     try:
         for node1, node2 in zip(nodes1, nodes2):
             data1 = _convert_node(node1)
@@ -74,15 +78,17 @@ test_path_resolver_loader.unittest = ['.data', '.path']
 def test_path_resolver_dumper(data_filename, path_filename, verbose=False):
     _make_path_loader_and_dumper()
     for filename in [data_filename, path_filename]:
-        output = yaml.serialize_all(yaml.compose_all(open(filename, 'rb')), Dumper=MyDumper)
+        with open(filename, 'rb') as file:
+            output = yaml.serialize_all(yaml.compose_all(file), Dumper=MyDumper)
         if verbose:
             print(output)
         nodes1 = yaml.compose_all(output)
-        nodes2 = yaml.compose_all(open(data_filename, 'rb'))
-        for node1, node2 in zip(nodes1, nodes2):
-            data1 = _convert_node(node1)
-            data2 = _convert_node(node2)
-            assert data1 == data2, (data1, data2)
+        with open(data_filename, 'rb') as file:
+            nodes2 = yaml.compose_all(file)
+            for node1, node2 in zip(nodes1, nodes2):
+                data1 = _convert_node(node1)
+                data2 = _convert_node(node2)
+                assert data1 == data2, (data1, data2)
 
 test_path_resolver_dumper.unittest = ['.data', '.path']
 

--- a/tests/lib/test_sort_keys.py
+++ b/tests/lib/test_sort_keys.py
@@ -3,8 +3,10 @@ import pprint
 import sys
 
 def test_sort_keys(input_filename, sorted_filename, verbose=False):
-    input = open(input_filename, 'rb').read().decode('utf-8')
-    sorted = open(sorted_filename, 'rb').read().decode('utf-8')
+    with open(input_filename, 'rb') as file:
+        input = file.read().decode('utf-8')
+    with open(sorted_filename, 'rb') as file:
+        sorted = file.read().decode('utf-8')
     data = yaml.load(input, Loader=yaml.FullLoader)
     dump_sorted = yaml.dump(data, default_flow_style=False, sort_keys=True)
     dump_unsorted = yaml.dump(data, default_flow_style=False, sort_keys=False)

--- a/tests/lib/test_structure.py
+++ b/tests/lib/test_structure.py
@@ -34,15 +34,19 @@ def _convert_structure(loader):
 
 def test_structure(data_filename, structure_filename, verbose=False):
     nodes1 = []
-    nodes2 = eval(open(structure_filename, 'r').read())
+    with open(structure_filename, 'r') as file:
+        nodes2 = eval(file.read())
     try:
-        loader = yaml.Loader(open(data_filename, 'rb'))
-        while loader.check_event():
-            if loader.check_event(yaml.StreamStartEvent, yaml.StreamEndEvent,
-                                yaml.DocumentStartEvent, yaml.DocumentEndEvent):
-                loader.get_event()
-                continue
-            nodes1.append(_convert_structure(loader))
+        with open(data_filename, 'rb') as file:
+            loader = yaml.Loader(file)
+            while loader.check_event():
+                if loader.check_event(
+                    yaml.StreamStartEvent, yaml.StreamEndEvent,
+                    yaml.DocumentStartEvent, yaml.DocumentEndEvent
+                ):
+                    loader.get_event()
+                    continue
+                nodes1.append(_convert_structure(loader))
         if len(nodes1) == 1:
             nodes1 = nodes1[0]
         assert nodes1 == nodes2, (nodes1, nodes2)
@@ -71,8 +75,10 @@ def test_parser(data_filename, canonical_filename, verbose=False):
     events1 = None
     events2 = None
     try:
-        events1 = list(yaml.parse(open(data_filename, 'rb')))
-        events2 = list(yaml.canonical_parse(open(canonical_filename, 'rb')))
+        with open(data_filename, 'rb') as file:
+            events1 = list(yaml.parse(file))
+        with open(canonical_filename, 'rb') as file:
+            events2 = list(yaml.canonical_parse(file))
         _compare_events(events1, events2)
     finally:
         if verbose:
@@ -87,8 +93,10 @@ def test_parser_on_canonical(canonical_filename, verbose=False):
     events1 = None
     events2 = None
     try:
-        events1 = list(yaml.parse(open(canonical_filename, 'rb')))
-        events2 = list(yaml.canonical_parse(open(canonical_filename, 'rb')))
+        with open(canonical_filename, 'rb') as file:
+            events1 = list(yaml.parse(file))
+        with open(canonical_filename, 'rb') as file:
+            events2 = list(yaml.canonical_parse(file))
         _compare_events(events1, events2, full=True)
     finally:
         if verbose:
@@ -117,8 +125,10 @@ def test_composer(data_filename, canonical_filename, verbose=False):
     nodes1 = None
     nodes2 = None
     try:
-        nodes1 = list(yaml.compose_all(open(data_filename, 'rb')))
-        nodes2 = list(yaml.canonical_compose_all(open(canonical_filename, 'rb')))
+        with open(data_filename, 'rb') as file:
+            nodes1 = list(yaml.compose_all(file))
+        with open(canonical_filename, 'rb') as file:
+            nodes2 = list(yaml.canonical_compose_all(file))
         assert len(nodes1) == len(nodes2), (len(nodes1), len(nodes2))
         for node1, node2 in zip(nodes1, nodes2):
             _compare_nodes(node1, node2)
@@ -169,8 +179,10 @@ def test_constructor(data_filename, canonical_filename, verbose=False):
     native1 = None
     native2 = None
     try:
-        native1 = list(yaml.load_all(open(data_filename, 'rb'), Loader=MyLoader))
-        native2 = list(yaml.load_all(open(canonical_filename, 'rb'), Loader=MyCanonicalLoader))
+        with open(data_filename, 'rb') as file:
+            native1 = list(yaml.load_all(file, Loader=MyLoader))
+        with open(canonical_filename, 'rb') as file:
+            native2 = list(yaml.load_all(file, Loader=MyCanonicalLoader))
         assert native1 == native2, (native1, native2)
     finally:
         if verbose:

--- a/tests/lib/test_tokens.py
+++ b/tests/lib/test_tokens.py
@@ -44,11 +44,13 @@ _replaces = {
 
 def test_tokens(data_filename, tokens_filename, verbose=False):
     tokens1 = []
-    tokens2 = open(tokens_filename, 'r').read().split()
+    with open(tokens_filename, 'r') as file:
+        tokens2 = file.read().split()
     try:
-        for token in yaml.scan(open(data_filename, 'rb')):
-            if not isinstance(token, (yaml.StreamStartToken, yaml.StreamEndToken)):
-                tokens1.append(_replaces[token.__class__])
+        with open(data_filename, 'rb') as file:
+            for token in yaml.scan(file):
+                if not isinstance(token, (yaml.StreamStartToken, yaml.StreamEndToken)):
+                    tokens1.append(_replaces[token.__class__])
     finally:
         if verbose:
             print("TOKENS1:", ' '.join(tokens1))
@@ -63,8 +65,9 @@ def test_scanner(data_filename, canonical_filename, verbose=False):
     for filename in [data_filename, canonical_filename]:
         tokens = []
         try:
-            for token in yaml.scan(open(filename, 'rb')):
-                tokens.append(token.__class__.__name__)
+            with open(filename, 'rb') as file:
+                for token in yaml.scan(file):
+                    tokens.append(token.__class__.__name__)
         finally:
             if verbose:
                 pprint.pprint(tokens)

--- a/tests/lib/test_yaml_ext.py
+++ b/tests/lib/test_yaml_ext.py
@@ -154,14 +154,14 @@ def _compare_scanners(py_data, c_data, verbose):
             pprint.pprint(c_tokens)
 
 def test_c_scanner(data_filename, canonical_filename, verbose=False):
-    _compare_scanners(open(data_filename, 'rb'),
-            open(data_filename, 'rb'), verbose)
-    _compare_scanners(open(data_filename, 'rb').read(),
-            open(data_filename, 'rb').read(), verbose)
-    _compare_scanners(open(canonical_filename, 'rb'),
-            open(canonical_filename, 'rb'), verbose)
-    _compare_scanners(open(canonical_filename, 'rb').read(),
-            open(canonical_filename, 'rb').read(), verbose)
+    with open(data_filename, 'rb') as file1, open(data_filename, 'rb') as file2:
+        _compare_scanners(file1, file2, verbose)
+    with open(data_filename, 'rb') as file1, open(data_filename, 'rb') as file2:
+        _compare_scanners(file1.read(), file2.read(), verbose)
+    with open(canonical_filename, 'rb') as file1, open(canonical_filename, 'rb') as file2:
+        _compare_scanners(file1, file2, verbose)
+    with open(canonical_filename, 'rb') as file1, open(canonical_filename, 'rb') as file2:
+        _compare_scanners(file1.read(), file2.read(), verbose)
 
 test_c_scanner.unittest = ['.data', '.canonical']
 test_c_scanner.skip = ['.skip-ext']
@@ -187,14 +187,14 @@ def _compare_parsers(py_data, c_data, verbose):
             pprint.pprint(c_events)
 
 def test_c_parser(data_filename, canonical_filename, verbose=False):
-    _compare_parsers(open(data_filename, 'rb'),
-            open(data_filename, 'rb'), verbose)
-    _compare_parsers(open(data_filename, 'rb').read(),
-            open(data_filename, 'rb').read(), verbose)
-    _compare_parsers(open(canonical_filename, 'rb'),
-            open(canonical_filename, 'rb'), verbose)
-    _compare_parsers(open(canonical_filename, 'rb').read(),
-            open(canonical_filename, 'rb').read(), verbose)
+    with open(data_filename, 'rb') as file1, open(data_filename, 'rb') as file2:
+        _compare_parsers(file1, file2, verbose)
+    with open(data_filename, 'rb') as file1, open(data_filename, 'rb') as file2:
+        _compare_parsers(file1.read(), file2.read(), verbose)
+    with open(canonical_filename, 'rb') as file1, open(canonical_filename, 'rb') as file2:
+        _compare_parsers(file1, file2, verbose)
+    with open(canonical_filename, 'rb') as file1, open(canonical_filename, 'rb') as file2:
+        _compare_parsers(file1.read(), file2.read(), verbose)
 
 test_c_parser.unittest = ['.data', '.canonical']
 test_c_parser.skip = ['.skip-ext']
@@ -232,8 +232,10 @@ def _compare_emitters(data, verbose):
             pprint.pprint(c_events)
 
 def test_c_emitter(data_filename, canonical_filename, verbose=False):
-    _compare_emitters(open(data_filename, 'rb').read(), verbose)
-    _compare_emitters(open(canonical_filename, 'rb').read(), verbose)
+    with open(data_filename, 'rb') as file:
+        _compare_emitters(file.read(), verbose)
+    with open(canonical_filename, 'rb') as file:
+        _compare_emitters(file.read(), verbose)
 
 test_c_emitter.unittest = ['.data', '.canonical']
 test_c_emitter.skip = ['.skip-ext']


### PR DESCRIPTION
Based on #542.

The tests often open files without ensuring that they are properly closed thereafter. Running `python -Wa setup.py test` produces a pile of resource warnings. This PR wraps all of the stray `open`s in `with` statements, eliminating the resource warnings.