### PR TITLE
Initial drop of libfyaml based backend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /lib/PyYAML.egg-info/*
 /wheelhouse/*
 /yaml/_yaml.c
+/fyaml/_fyaml.c
 MANIFEST
 **/*.so
 **/*.dylib

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+find ./ -name '*.pyx' -exec cython \{\} \;

--- a/examples/fyaml/test-libfyaml.py
+++ b/examples/fyaml/test-libfyaml.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+if __name__ == '__main__':
+
+    # import the yaml module in the build/lib directory
+    import sys, os, distutils.util
+    build_lib = 'build/lib'
+    build_lib_ext = os.path.join('build', 'lib.{}-{}.{}'.format(distutils.util.get_platform(), *sys.version_info))
+    sys.path.insert(0, build_lib)
+    sys.path.insert(0, build_lib_ext)
+
+    import yaml._fyaml, yaml
+    import types, pprint, tempfile, sys, os
+
+    version = yaml._fyaml.get_version_string()
+
+    print("libfyaml version:", version)
+
+    obj = yaml.load("""
+        - Hesperiidae
+        - Papilionidae
+        - Apatelodidae
+        - Epiplemidae
+        """, Loader=yaml.FLoader)
+    assert (obj != None)
+    print(obj)
+
+    obj = yaml.load("""
+        foo
+        """, Loader=yaml.FLoader)
+    assert (obj != None)
+    print(obj)
+
+    obj = yaml.load("""
+        foo: bar
+        """, Loader=yaml.FLoader)
+    assert (obj != None)
+    print(obj)
+
+    obj = yaml.load("""
+        foo: bar
+        baz: frooz
+        seq: [ 1, 2, 3 ]
+        """, Loader=yaml.FLoader)
+    assert (obj != None)
+    print(obj)
+
+    obj = yaml.load("""
+        - &foo Hesperiidae
+        - *foo
+        """, Loader=yaml.FLoader)
+    assert (obj != None)
+    print(obj)
+
+    obj = yaml.load("""
+        - Hesperiidae
+        - !!str "10"
+        """, Loader=yaml.FLoader)
+    assert (obj != None)
+    print(obj)
+
+    document = """
+                foo: bar
+                "bar":
+                  - baz
+                  - 1
+                test: |
+                  literal
+               """
+
+    print("scan, python loader")
+    tokens = yaml.scan(document, Loader=yaml.Loader)
+    for token in tokens:
+        print("  ", token)
+
+    print("scan, f loader")
+    tokens = yaml.scan(document, Loader=yaml.FLoader)
+    for token in tokens:
+        print("  ", token)
+
+    print("parse, python loader")
+    events = yaml.parse(document, Loader=yaml.Loader)
+    for event in events:
+        print("  ", event)
+
+    print("parse, f loader")
+    events = yaml.parse(document, Loader=yaml.FLoader)
+    for event in events:
+        print("  ", event)
+
+    document = """
+        ? |-
+          foo
+        : |-
+          bar
+        """
+
+    print("parse, python loader")
+    events = yaml.parse(document, Loader=yaml.Loader)
+    for event in events:
+        print("  ", event)
+
+    print("parse, f loader")
+    events = yaml.parse(document, Loader=yaml.FLoader)
+    for event in events:
+        print("  ", event)
+
+    print("test, native emitter")
+    print(yaml.dump('scalar'))
+
+    print("test, f emitter")
+    print(yaml.dump('scalar', Dumper=yaml.FDumper))
+
+    print("test, f emitter (2)")
+    print(yaml.dump({'name': 'Silenthand Olleander', 'race': 'Human', 'traits': ['ONE_HAND', 'ONE_EYE']}, Dumper=yaml.FDumper))
+

--- a/fyaml/_fyaml.h
+++ b/fyaml/_fyaml.h
@@ -1,0 +1,69 @@
+
+#include <libfyaml.h>
+
+/* same as fy_event but cython doesn't do anonymous unions... yeah... */
+/* NOTE that this must be kept in sync _manually_ */
+/* ALSO all methods that take a fy_event * must be cast */
+struct _fy_event {
+	enum fy_event_type type;
+	/* eponymous union */
+	union {
+		struct {
+			struct fy_token *stream_start;
+		} stream_start;
+
+		struct {
+			struct fy_token *stream_end;
+		} stream_end;
+
+		struct {
+			struct fy_token *document_start;
+			struct fy_document_state *document_state;
+			bool implicit;
+		} document_start;
+
+		struct {
+			struct fy_token *document_end;
+			bool implicit;
+		} document_end;
+
+		struct {
+			struct fy_token *anchor;
+		} alias;
+
+		struct {
+			struct fy_token *anchor;
+			struct fy_token *tag;
+			struct fy_token *value;
+			bool tag_implicit;
+		} scalar;
+
+		struct {
+			struct fy_token *anchor;
+			struct fy_token *tag;
+			struct fy_token *sequence_start;
+		} sequence_start;
+
+		struct {
+			struct fy_token *sequence_end;
+		} sequence_end;
+
+		struct {
+			struct fy_token *anchor;
+			struct fy_token *tag;
+			struct fy_token *mapping_start;
+		} mapping_start;
+
+		struct {
+			struct fy_token *mapping_end;
+		} mapping_end;
+	} data;
+};
+
+#ifdef _MSC_VER	/* MS Visual C++ 6.0 */
+#if _MSC_VER == 1200
+
+#define PyLong_FromUnsignedLongLong(z)	PyInt_FromLong(i)
+
+#endif
+#endif

--- a/fyaml/_fyaml.pxd
+++ b/fyaml/_fyaml.pxd
@@ -1,0 +1,938 @@
+
+cdef extern from "_fyaml.h":
+
+    void malloc(int l)
+    void free(void *ptr)
+    void memcpy(void *d, char *s, int l)
+    void *memset(void *s, int c, size_t len)
+    int strlen(char *s)
+    int printf(const char *fmt, ...)
+
+    int PyBytes_CheckExact(object o)
+    int PyUnicode_CheckExact(object o)
+    char *PyBytes_AS_STRING(object o)
+    int PyBytes_GET_SIZE(object o)
+    object PyBytes_FromStringAndSize(char *v, int l)
+    object PyUnicode_FromString(char *u)
+    object PyUnicode_DecodeUTF8(char *u, int s, char *e)
+    object PyUnicode_AsUTF8String(object o)
+    int PY_MAJOR_VERSION
+
+    cdef struct fy_token:
+        pass
+    cdef struct fy_document_state:
+        pass
+    cdef struct fy_parser:
+        pass
+    cdef struct fy_emitter:
+        pass
+    cdef struct fy_document:
+        pass
+    cdef struct fy_node:
+        pass
+    cdef struct fy_node_pair:
+        pass
+    cdef struct fy_anchor:
+        pass
+    cdef struct fy_node_mapping_sort_ctx:
+        pass
+    cdef struct fy_token_iter:
+        pass
+    cdef struct fy_diag:
+        pass
+    cdef struct fy_path_parser:
+        pass
+    cdef struct fy_path_expr:
+        pass
+    cdef struct fy_path_exec:
+        pass
+
+    cdef struct fy_version:
+        int major
+        int minor
+    cdef struct fy_tag:
+        char* handle
+        char* prefix
+    cdef struct fy_mark:
+        size_t input_pos
+        int line
+        int column
+
+    cdef enum fy_error_type:
+        FYET_DEBUG
+        FYET_INFO
+        FYET_NOTICE
+        FYET_WARNING
+        FYET_ERROR
+        FYET_MAX
+
+    cdef enum fy_error_module:
+        FYEM_UNKNOWN
+        FYEM_ATOM
+        FYEM_SCAN
+        FYEM_PARSE
+        FYEM_DOC
+        FYEM_BUILD
+        FYEM_INTERNAL
+        FYEM_SYSTEM
+        FYEM_MAX
+
+    cdef enum fy_parse_cfg_flags:
+        FYPCF_QUIET                 =   1    # FY_BIT(0)
+        FYPCF_COLLECT_DIAG          =   2    # FY_BIT(1)
+        FYPCF_RESOLVE_DOCUMENT      =   4    # FY_BIT(2)
+        FYPCF_DISABLE_MMAP_OPT      =   8    # FY_BIT(3)
+        FYPCF_DISABLE_RECYCLING     =  16    # FY_BIT(4)
+        FYPCF_PARSE_COMMENTS        =  32    # FY_BIT(5)
+        FYPCF_DISABLE_DEPTH_LIMIT   =  64    # FY_BIT(6)
+        FYPCF_DISABLE_ACCELERATORS  = 128    # FY_BIT(7)
+        FYPCF_DISABLE_BUFFERING     = 256    # FY_BIT(8)
+        FYPCF_DEFAULT_VERSION_AUTO	=      0 # 0 << 9
+        FYPCF_DEFAULT_VERSION_1_1	=    512 # 1 << 9
+        FYPCF_DEFAULT_VERSION_1_2	=   1024 # 2 << 9
+        FYPCF_DEFAULT_VERSION_1_3	=   1536 # 3 << 9
+        FYPCF_SLOPPY_FLOW_INDENTATION = 16384 # FY_BIT(14)
+        FYPCF_JSON_AUTO             =      0 # 0 << 16
+        FYPCF_JSON_NONE             =  65536 # 1 << 16
+        FYPCF_JSON_FORCE            = 131072 # 2 << 16
+
+    cdef struct fy_parse_cfg:
+        char* search_path
+        fy_parse_cfg_flags flags
+        void* userdata
+        fy_diag* diag
+
+    cdef enum fy_event_type:
+        FYET_NONE
+        FYET_STREAM_START
+        FYET_STREAM_END
+        FYET_DOCUMENT_START
+        FYET_DOCUMENT_END
+        FYET_MAPPING_START
+        FYET_MAPPING_END
+        FYET_SEQUENCE_START
+        FYET_SEQUENCE_END
+        FYET_SCALAR
+        FYET_ALIAS
+
+    cdef enum fy_scalar_style:
+        FYSS_ANY
+        FYSS_PLAIN
+        FYSS_SINGLE_QUOTED
+        FYSS_DOUBLE_QUOTED
+        FYSS_LITERAL
+        FYSS_FOLDED
+        FYSS_MAX
+
+    cdef struct _fy_event_stream_start_s:
+        fy_token* stream_start
+
+    cdef struct _fy_event_stream_end_s:
+        fy_token* stream_end
+
+    cdef struct _fy_event_document_start_s:
+        fy_token* document_start
+        fy_document_state* document_state
+        bint implicit
+
+    cdef struct _fy_event_document_end_s:
+        fy_token* document_end
+        bint implicit
+
+    cdef struct _fy_event_alias_s:
+        fy_token* anchor
+
+    cdef struct _fy_event_scalar_s:
+        fy_token* anchor
+        fy_token* tag
+        fy_token* value
+        bint tag_implicit
+
+    cdef struct _fy_event_sequence_start_s:
+        fy_token* anchor
+        fy_token* tag
+        fy_token* sequence_start
+
+    cdef struct _fy_event_sequence_end_s:
+        fy_token* sequence_end
+
+    cdef struct _fy_event_mapping_start_s:
+        fy_token* anchor
+        fy_token* tag
+        fy_token* mapping_start
+
+    cdef struct _fy_event_mapping_end_s:
+        fy_token* mapping_end
+
+    cdef union _fy_event_u:
+        _fy_event_stream_start_s stream_start
+        _fy_event_stream_end_s stream_end
+        _fy_event_document_start_s document_start
+        _fy_event_document_end_s document_end
+        _fy_event_alias_s alias
+        _fy_event_scalar_s scalar
+        _fy_event_sequence_start_s sequence_start
+        _fy_event_sequence_end_s sequence_end
+        _fy_event_mapping_start_s mapping_start
+        _fy_event_mapping_end_s mapping_end
+
+    cdef struct fy_event:
+        fy_event_type type
+
+    cdef struct _fy_event:
+        fy_event_type type
+        _fy_event_u data
+
+    const char* fy_library_version()
+
+    fy_error_type fy_string_to_error_type(char* str)
+
+    char* fy_error_type_to_string(fy_error_type type)
+
+    fy_error_module fy_string_to_error_module(char* str)
+
+    char* fy_error_module_to_string(fy_error_module module)
+
+    bint fy_event_is_implicit(fy_event* fye)
+
+    bint fy_document_event_is_implicit(fy_event* fye)
+
+    fy_parser* fy_parser_create(fy_parse_cfg* cfg)
+
+    void fy_parser_destroy(fy_parser* fyp)
+
+    fy_parse_cfg* fy_parser_get_cfg(fy_parser* fyp)
+
+    fy_diag* fy_parser_get_diag(fy_parser* fyp)
+
+    int fy_parser_set_diag(fy_parser* fyp, fy_diag* diag)
+
+    int fy_parser_reset(fy_parser* fyp)
+
+    int fy_parser_set_input_file(fy_parser* fyp, char* file)
+
+    int fy_parser_set_string(fy_parser* fyp, char* str, size_t len)
+
+    int fy_parser_set_malloc_string(fy_parser* fyp, char* str, size_t len)
+
+    # int fy_parser_set_input_fp(fy_parser* fyp, char* name, FILE* fp)
+
+    ctypedef ssize_t (*_fy_parser_set_input_callback_callback_ft)(void* user, void* buf, size_t count)
+
+    int fy_parser_set_input_callback(fy_parser* fyp, void* user, _fy_parser_set_input_callback_callback_ft callback)
+
+    fy_event* fy_parser_parse(fy_parser* fyp)
+
+    void fy_parser_event_free(fy_parser* fyp, fy_event* fye)
+
+    bint fy_parser_get_stream_error(fy_parser* fyp)
+
+    fy_scalar_style fy_token_scalar_style(fy_token* fyt)
+
+    char* fy_token_get_text(fy_token* fyt, size_t* lenp)
+
+    char* fy_token_get_text0(fy_token* fyt)
+
+    size_t fy_token_get_text_length(fy_token* fyt)
+
+    size_t fy_token_get_utf8_length(fy_token* fyt)
+
+    cdef struct fy_iter_chunk:
+        char* str
+        size_t len
+
+    fy_token_iter* fy_token_iter_create(fy_token* fyt)
+
+    void fy_token_iter_destroy(fy_token_iter* iter)
+
+    void fy_token_iter_start(fy_token* fyt, fy_token_iter* iter)
+
+    void fy_token_iter_finish(fy_token_iter* iter)
+
+    fy_iter_chunk* fy_token_iter_peek_chunk(fy_token_iter* iter)
+
+    fy_iter_chunk* fy_token_iter_chunk_next(fy_token_iter* iter, fy_iter_chunk* curr, int* errp)
+
+    void fy_token_iter_advance(fy_token_iter* iter, size_t len)
+
+    ssize_t fy_token_iter_read(fy_token_iter* iter, void* buf, size_t count)
+
+    int fy_token_iter_getc(fy_token_iter* iter)
+
+    int fy_token_iter_ungetc(fy_token_iter* iter, int c)
+
+    int fy_token_iter_peekc(fy_token_iter* iter)
+
+    int fy_token_iter_utf8_get(fy_token_iter* iter)
+
+    int fy_token_iter_utf8_unget(fy_token_iter* iter, int c)
+
+    int fy_token_iter_utf8_peek(fy_token_iter* iter)
+
+    fy_document* fy_parse_load_document(fy_parser* fyp)
+
+    void fy_parse_document_destroy(fy_parser* fyp, fy_document* fyd)
+
+    int fy_document_resolve(fy_document* fyd)
+
+    bint fy_document_has_directives(fy_document* fyd)
+
+    bint fy_document_has_explicit_document_start(fy_document* fyd)
+
+    bint fy_document_has_explicit_document_end(fy_document* fyd)
+
+    fy_document* fy_node_document(fy_node* fyn)
+
+    cdef enum fy_emitter_write_type:
+        fyewt_document_indicator
+        fyewt_tag_directive
+        fyewt_version_directive
+        fyewt_indent
+        fyewt_indicator
+        fyewt_whitespace
+        fyewt_plain_scalar
+        fyewt_single_quoted_scalar
+        fyewt_double_quoted_scalar
+        fyewt_literal_scalar
+        fyewt_folded_scalar
+        fyewt_anchor
+        fyewt_tag
+        fyewt_linebreak
+        fyewt_alias
+        fyewt_terminating_zero
+        fyewt_plain_scalar_key
+        fyewt_single_quoted_scalar_key
+        fyewt_double_quoted_scalar_key
+        fyewt_comment
+
+    cdef enum fy_emitter_cfg_flags:
+        FYECF_SORT_KEYS
+        FYECF_OUTPUT_COMMENTS
+        FYECF_STRIP_LABELS
+        FYECF_STRIP_TAGS
+        FYECF_STRIP_DOC
+        FYECF_INDENT_DEFAULT
+        FYECF_INDENT_1
+        FYECF_INDENT_2
+        FYECF_INDENT_3
+        FYECF_INDENT_4
+        FYECF_INDENT_5
+        FYECF_INDENT_6
+        FYECF_INDENT_7
+        FYECF_INDENT_8
+        FYECF_INDENT_9
+        FYECF_WIDTH_DEFAULT
+        FYECF_WIDTH_80
+        FYECF_WIDTH_132
+        FYECF_WIDTH_INF
+        FYECF_MODE_ORIGINAL
+        FYECF_MODE_BLOCK
+        FYECF_MODE_FLOW
+        FYECF_MODE_FLOW_ONELINE
+        FYECF_MODE_JSON
+        FYECF_MODE_JSON_TP
+        FYECF_MODE_JSON_ONELINE
+        FYECF_MODE_DEJSON
+        FYECF_DOC_START_MARK_AUTO
+        FYECF_DOC_START_MARK_OFF
+        FYECF_DOC_START_MARK_ON
+        FYECF_DOC_END_MARK_AUTO
+        FYECF_DOC_END_MARK_OFF
+        FYECF_DOC_END_MARK_ON
+        FYECF_VERSION_DIR_AUTO
+        FYECF_VERSION_DIR_OFF
+        FYECF_VERSION_DIR_ON
+        FYECF_TAG_DIR_AUTO
+        FYECF_TAG_DIR_OFF
+        FYECF_TAG_DIR_ON
+        FYECF_DEFAULT
+
+    cdef enum:
+        FYECF_INDENT_SHIFT
+        FYECF_INDENT_MASK
+        FYECF_WIDTH_SHIFT
+        FYECF_WIDTH_MASK
+
+    ctypedef int (*_fy_emitter_cfg_output_ft)(fy_emitter* emit, fy_emitter_write_type type, const char* str, int len, void* userdata)
+
+    cdef struct fy_emitter_cfg:
+        fy_emitter_cfg_flags flags
+        _fy_emitter_cfg_output_ft output
+        void* userdata
+        fy_diag* diag
+
+    fy_emitter* fy_emitter_create(fy_emitter_cfg* cfg)
+
+    void fy_emitter_destroy(fy_emitter* emit)
+
+    fy_emitter_cfg* fy_emitter_get_cfg(fy_emitter* emit)
+
+    fy_diag* fy_emitter_get_diag(fy_emitter* emit)
+
+    int fy_emitter_set_diag(fy_emitter* emit, fy_diag* diag)
+
+    int fy_emit_event(fy_emitter* emit, fy_event* fye)
+
+    int fy_emit_document(fy_emitter* emit, fy_document* fyd)
+
+    int fy_emit_document_start(fy_emitter* emit, fy_document* fyd, fy_node* fyn)
+
+    int fy_emit_document_end(fy_emitter* emit)
+
+    int fy_emit_node(fy_emitter* emit, fy_node* fyn)
+
+    int fy_emit_root_node(fy_emitter* emit, fy_node* fyn)
+
+    int fy_emit_explicit_document_end(fy_emitter* emit)
+
+    # int fy_emit_document_to_fp(fy_document* fyd, fy_emitter_cfg_flags flags, FILE* fp)
+
+    int fy_emit_document_to_file(fy_document* fyd, fy_emitter_cfg_flags flags, char* filename)
+
+    int fy_emit_document_to_buffer(fy_document* fyd, fy_emitter_cfg_flags flags, char* buf, int size)
+
+    char* fy_emit_document_to_string(fy_document* fyd, fy_emitter_cfg_flags flags)
+
+    int fy_emit_node_to_buffer(fy_node* fyn, fy_emitter_cfg_flags flags, char* buf, int size)
+
+    char* fy_emit_node_to_string(fy_node* fyn, fy_emitter_cfg_flags flags)
+
+    fy_node* fy_node_copy(fy_document* fyd, fy_node* fyn_from)
+
+    int fy_node_insert(fy_node* fyn_to, fy_node* fyn_from)
+
+    int fy_document_insert_at(fy_document* fyd, char* path, size_t pathlen, fy_node* fyn)
+
+    cdef enum fy_node_type:
+        FYNT_SCALAR
+        FYNT_SEQUENCE
+        FYNT_MAPPING
+
+    cdef enum fy_node_style:
+        FYNS_ANY
+        FYNS_FLOW
+        FYNS_BLOCK
+        FYNS_PLAIN
+        FYNS_SINGLE_QUOTED
+        FYNS_DOUBLE_QUOTED
+        FYNS_LITERAL
+        FYNS_FOLDED
+        FYNS_ALIAS
+
+    cdef enum fy_node_walk_flags:
+        FYNWF_DONT_FOLLOW
+        FYNWF_FOLLOW
+        FYNWF_PTR_YAML
+        FYNWF_PTR_JSON
+        FYNWF_PTR_RELJSON
+        FYNWF_URI_ENCODED
+        FYNWF_MAXDEPTH_DEFAULT
+        FYNWF_MARKER_DEFAULT
+        FYNWF_PTR_DEFAULT
+
+    fy_node_style fy_node_style_from_scalar_style(fy_scalar_style sstyle)
+
+    ctypedef int (*fy_node_mapping_sort_fn)(fy_node_pair* fynp_a, fy_node_pair* fynp_b, void* arg)
+
+    ctypedef int (*fy_node_scalar_compare_fn)(fy_node* fyn_a, fy_node* fyn_b, void* arg)
+
+    bint fy_node_compare(fy_node* fyn1, fy_node* fyn2)
+
+    bint fy_node_compare_user(fy_node* fyn1, fy_node* fyn2, fy_node_mapping_sort_fn sort_fn, void* sort_fn_arg, fy_node_scalar_compare_fn cmp_fn, void* cmp_fn_arg)
+
+    bint fy_node_compare_string(fy_node* fyn, char* str, size_t len)
+
+    fy_document* fy_document_create(fy_parse_cfg* cfg)
+
+    void fy_document_destroy(fy_document* fyd)
+
+    fy_parse_cfg* fy_document_get_cfg(fy_document* fyd)
+
+    fy_diag* fy_document_get_diag(fy_document* fyd)
+
+    int fy_document_set_diag(fy_document* fyd, fy_diag* diag)
+
+    int fy_document_set_parent(fy_document* fyd, fy_document* fyd_child)
+
+    fy_document* fy_document_build_from_string(fy_parse_cfg* cfg, char* str, size_t len)
+
+    fy_document* fy_document_build_from_malloc_string(fy_parse_cfg* cfg, char* str, size_t len)
+
+    fy_document* fy_document_build_from_file(fy_parse_cfg* cfg, char* file)
+
+    # fy_document* fy_document_build_from_fp(fy_parse_cfg* cfg, FILE* fp)
+
+    # fy_document* fy_document_vbuildf(fy_parse_cfg* cfg, char* fmt, va_list ap)
+
+    fy_document* fy_document_buildf(fy_parse_cfg* cfg, char* fmt)
+
+    fy_node* fy_document_root(fy_document* fyd)
+
+    int fy_document_set_root(fy_document* fyd, fy_node* fyn)
+
+    fy_node_type fy_node_get_type(fy_node* fyn)
+
+    fy_node_style fy_node_get_style(fy_node* fyn)
+
+    bint fy_node_is_scalar(fy_node* fyn)
+
+    bint fy_node_is_sequence(fy_node* fyn)
+
+    bint fy_node_is_mapping(fy_node* fyn)
+
+    bint fy_node_is_alias(fy_node* fyn)
+
+    bint fy_node_is_attached(fy_node* fyn)
+
+    fy_token* fy_node_get_tag_token(fy_node* fyn)
+
+    fy_token* fy_node_get_scalar_token(fy_node* fyn)
+
+    fy_node* fy_node_resolve_alias(fy_node* fyn)
+
+    fy_node* fy_node_dereference(fy_node* fyn)
+
+    int fy_node_free(fy_node* fyn)
+
+    fy_node* fy_node_build_from_string(fy_document* fyd, char* str, size_t len)
+
+    fy_node* fy_node_build_from_malloc_string(fy_document* fyd, char* str, size_t len)
+
+    fy_node* fy_node_build_from_file(fy_document* fyd, char* file)
+
+    # fy_node* fy_node_build_from_fp(fy_document* fyd, FILE* fp)
+
+    # fy_node* fy_node_vbuildf(fy_document* fyd, char* fmt, va_list ap)
+
+    fy_node* fy_node_buildf(fy_document* fyd, char* fmt)
+
+    fy_node* fy_node_by_path(fy_node* fyn, char* path, size_t len, fy_node_walk_flags flags)
+
+    char* fy_node_get_path(fy_node* fyn)
+
+    fy_node* fy_node_get_parent(fy_node* fyn)
+
+    char* fy_node_get_parent_address(fy_node* fyn)
+
+    char* fy_node_get_path_relative_to(fy_node* fyn_parent, fy_node* fyn)
+
+    char* fy_node_get_short_path(fy_node* fyn)
+
+    char* fy_node_get_reference(fy_node* fyn)
+
+    fy_node* fy_node_create_reference(fy_node* fyn)
+
+    char* fy_node_get_relative_reference(fy_node* fyn_base, fy_node* fyn)
+
+    fy_node* fy_node_create_relative_reference(fy_node* fyn_base, fy_node* fyn)
+
+    fy_node* fy_node_create_scalar(fy_document* fyd, char* data, size_t size)
+
+    fy_node* fy_node_create_scalar_copy(fy_document* fyd, char* data, size_t size)
+
+    # fy_node* fy_node_create_vscalarf(fy_document* fyd, char* fmt, va_list ap)
+
+    fy_node* fy_node_create_scalarf(fy_document* fyd, char* fmt)
+
+    fy_node* fy_node_create_sequence(fy_document* fyd)
+
+    fy_node* fy_node_create_mapping(fy_document* fyd)
+
+    int fy_node_set_tag(fy_node* fyn, char* data, size_t len)
+
+    char* fy_node_get_tag(fy_node* fyn, size_t* lenp)
+
+    char* fy_node_get_scalar(fy_node* fyn, size_t* lenp)
+
+    char* fy_node_get_scalar0(fy_node* fyn)
+
+    size_t fy_node_get_scalar_length(fy_node* fyn)
+
+    size_t fy_node_get_scalar_utf8_length(fy_node* fyn)
+
+    fy_node* fy_node_sequence_iterate(fy_node* fyn, void** prevp)
+
+    fy_node* fy_node_sequence_reverse_iterate(fy_node* fyn, void** prevp)
+
+    int fy_node_sequence_item_count(fy_node* fyn)
+
+    bint fy_node_sequence_is_empty(fy_node* fyn)
+
+    fy_node* fy_node_sequence_get_by_index(fy_node* fyn, int index)
+
+    int fy_node_sequence_append(fy_node* fyn_seq, fy_node* fyn)
+
+    int fy_node_sequence_prepend(fy_node* fyn_seq, fy_node* fyn)
+
+    int fy_node_sequence_insert_before(fy_node* fyn_seq, fy_node* fyn_mark, fy_node* fyn)
+
+    int fy_node_sequence_insert_after(fy_node* fyn_seq, fy_node* fyn_mark, fy_node* fyn)
+
+    fy_node* fy_node_sequence_remove(fy_node* fyn_seq, fy_node* fyn)
+
+    fy_node_pair* fy_node_mapping_iterate(fy_node* fyn, void** prevp)
+
+    fy_node_pair* fy_node_mapping_reverse_iterate(fy_node* fyn, void** prevp)
+
+    int fy_node_mapping_item_count(fy_node* fyn)
+
+    bint fy_node_mapping_is_empty(fy_node* fyn)
+
+    fy_node_pair* fy_node_mapping_get_by_index(fy_node* fyn, int index)
+
+    fy_node* fy_node_mapping_lookup_by_string(fy_node* fyn, char* key, size_t len)
+
+    fy_node_pair* fy_node_mapping_lookup_pair_by_simple_key(fy_node* fyn, char* key, size_t len)
+
+    fy_node* fy_node_mapping_lookup_value_by_simple_key(fy_node* fyn, char* key, size_t len)
+
+    char* fy_node_mapping_lookup_scalar_by_simple_key(fy_node* fyn, size_t* lenp, char* key, size_t keylen)
+
+    char* fy_node_mapping_lookup_scalar0_by_simple_key(fy_node* fyn, char* key, size_t keylen)
+
+    fy_node_pair* fy_node_mapping_lookup_pair(fy_node* fyn, fy_node* fyn_key)
+
+    fy_node* fy_node_mapping_lookup_value_by_key(fy_node* fyn, fy_node* fyn_key)
+
+    int fy_node_mapping_get_pair_index(fy_node* fyn, fy_node_pair* fynp)
+
+    fy_node* fy_node_pair_key(fy_node_pair* fynp)
+
+    fy_node* fy_node_pair_value(fy_node_pair* fynp)
+
+    int fy_node_pair_set_key(fy_node_pair* fynp, fy_node* fyn)
+
+    int fy_node_pair_set_value(fy_node_pair* fynp, fy_node* fyn)
+
+    int fy_node_mapping_append(fy_node* fyn_map, fy_node* fyn_key, fy_node* fyn_value)
+
+    int fy_node_mapping_prepend(fy_node* fyn_map, fy_node* fyn_key, fy_node* fyn_value)
+
+    int fy_node_mapping_remove(fy_node* fyn_map, fy_node_pair* fynp)
+
+    fy_node* fy_node_mapping_remove_by_key(fy_node* fyn_map, fy_node* fyn_key)
+
+    int fy_node_sort(fy_node* fyn, fy_node_mapping_sort_fn key_cmp, void* arg)
+
+    # int fy_node_vscanf(fy_node* fyn, char* fmt, va_list ap)
+
+    int fy_node_scanf(fy_node* fyn, char* fmt)
+
+    # int fy_document_vscanf(fy_document* fyd, char* fmt, va_list ap)
+
+    int fy_document_scanf(fy_document* fyd, char* fmt)
+
+    fy_token* fy_document_tag_directive_iterate(fy_document* fyd, void** prevp)
+
+    fy_token* fy_document_tag_directive_lookup(fy_document* fyd, char* handle)
+
+    char* fy_tag_directive_token_handle(fy_token* fyt, size_t* lenp)
+
+    char* fy_tag_directive_token_prefix(fy_token* fyt, size_t* lenp)
+
+    int fy_document_tag_directive_add(fy_document* fyd, char* handle, char* prefix)
+
+    int fy_document_tag_directive_remove(fy_document* fyd, char* handle)
+
+    fy_anchor* fy_document_lookup_anchor(fy_document* fyd, char* anchor, size_t len)
+
+    fy_anchor* fy_document_lookup_anchor_by_token(fy_document* fyd, fy_token* anchor)
+
+    fy_anchor* fy_document_lookup_anchor_by_node(fy_document* fyd, fy_node* fyn)
+
+    char* fy_anchor_get_text(fy_anchor* fya, size_t* lenp)
+
+    fy_node* fy_anchor_node(fy_anchor* fya)
+
+    fy_anchor* fy_document_anchor_iterate(fy_document* fyd, void** prevp)
+
+    int fy_document_set_anchor(fy_document* fyd, fy_node* fyn, char* text, size_t len)
+
+    int fy_node_set_anchor(fy_node* fyn, char* text, size_t len)
+
+    int fy_node_set_anchor_copy(fy_node* fyn, char* text, size_t len)
+
+    # int fy_node_set_vanchorf(fy_node* fyn, char* fmt, va_list ap)
+
+    int fy_node_set_anchorf(fy_node* fyn, char* fmt)
+
+    int fy_node_remove_anchor(fy_node* fyn)
+
+    fy_anchor* fy_node_get_anchor(fy_node* fyn)
+
+    fy_anchor* fy_node_get_nearest_anchor(fy_node* fyn)
+
+    fy_node* fy_node_get_nearest_child_of(fy_node* fyn_base, fy_node* fyn)
+
+    fy_node* fy_node_create_alias(fy_document* fyd, char* alias, size_t len)
+
+    fy_node* fy_node_create_alias_copy(fy_document* fyd, char* alias, size_t len)
+
+    void* fy_node_get_meta(fy_node* fyn)
+
+    int fy_node_set_meta(fy_node* fyn, void* meta)
+
+    void fy_node_clear_meta(fy_node* fyn)
+
+    ctypedef void (*fy_node_meta_clear_fn)(fy_node* fyn, void* meta, void* user)
+
+    int fy_document_register_meta(fy_document* fyd, fy_node_meta_clear_fn clear_fn, void* user)
+
+    void fy_document_unregister_meta(fy_document* fyd)
+
+    bint fy_node_set_marker(fy_node* fyn, unsigned int marker)
+
+    bint fy_node_clear_marker(fy_node* fyn, unsigned int marker)
+
+    bint fy_node_is_marker_set(fy_node* fyn, unsigned int marker)
+
+    # void fy_node_vreport(fy_node* fyn, fy_error_type type, char* fmt, va_list ap)
+
+    void fy_node_report(fy_node* fyn, fy_error_type type, char* fmt)
+
+    # void fy_node_override_vreport(fy_node* fyn, fy_error_type type, char* file, int line, int column, char* fmt, va_list ap)
+
+    void fy_node_override_report(fy_node* fyn, fy_error_type type, char* file, int line, int column, char* fmt)
+
+    ctypedef void (*fy_diag_output_fn)(fy_diag* diag, void* user, char* buf, size_t len)
+
+    cdef struct fy_diag_cfg:
+        void* fp        # was FILE*
+        fy_diag_output_fn output_fn
+        void* user
+        fy_error_type level
+        unsigned int module_mask
+        bint colorize
+        bint show_source
+        bint show_position
+        bint show_type
+        bint show_module
+        int source_width
+        int position_width
+        int type_width
+        int module_width
+
+    fy_diag* fy_diag_create(fy_diag_cfg* cfg)
+
+    void fy_diag_destroy(fy_diag* diag)
+
+    fy_diag_cfg* fy_diag_get_cfg(fy_diag* diag)
+
+    void fy_diag_set_cfg(fy_diag* diag, fy_diag_cfg* cfg)
+
+    void fy_diag_set_level(fy_diag* diag, fy_error_type level)
+
+    void fy_diag_set_colorize(fy_diag* diag, bint colorize)
+
+    fy_diag* fy_diag_ref(fy_diag* diag)
+
+    void fy_diag_unref(fy_diag* diag)
+
+    bint fy_diag_got_error(fy_diag* diag)
+
+    void fy_diag_reset_error(fy_diag* diag)
+
+    void fy_diag_cfg_default(fy_diag_cfg* cfg)
+
+    void fy_diag_cfg_from_parser_flags(fy_diag_cfg* cfg, fy_parse_cfg_flags pflags)
+
+    # int fy_diag_vprintf(fy_diag* diag, char* fmt, va_list ap)
+
+    int fy_diag_printf(fy_diag* diag, char* fmt, ...)
+
+    cdef struct fy_diag_ctx:
+        fy_error_type level
+        fy_error_module module
+        char* source_func
+        char* source_file
+        int source_line
+        char* file
+        int line
+        int column
+
+    # int fy_vdiag(fy_diag* diag, fy_diag_ctx* fydc, char* fmt, va_list ap)
+
+    int fy_diagf(fy_diag* diag, fy_diag_ctx* fydc, char* fmt)
+
+    # void fy_diag_node_vreport(fy_diag* diag, fy_node* fyn, fy_error_type type, char* fmt, va_list ap)
+
+    void fy_diag_node_report(fy_diag* diag, fy_node* fyn, fy_error_type type, char* fmt)
+
+    # void fy_diag_node_override_vreport(fy_diag* diag, fy_node* fyn, fy_error_type type, char* file, int line, int column, char* fmt, va_list ap)
+
+    void fy_diag_node_override_report(fy_diag* diag, fy_node* fyn, fy_error_type type, char* file, int line, int column, char* fmt)
+
+    cdef enum fy_path_parse_cfg_flags:
+        FYPPCF_QUIET
+        FYPPCF_DISABLE_RECYCLING
+        FYPPCF_DISABLE_ACCELERATORS
+
+    cdef struct fy_path_parse_cfg:
+        fy_path_parse_cfg_flags flags
+        void* userdata
+        fy_diag* diag
+
+    fy_path_parser* fy_path_parser_create(fy_path_parse_cfg* cfg)
+
+    void fy_path_parser_destroy(fy_path_parser* fypp)
+
+    int fy_path_parser_reset(fy_path_parser* fypp)
+
+    fy_path_expr* fy_path_parse_expr_from_string(fy_path_parser* fypp, char* str, size_t len)
+
+    fy_path_expr* fy_path_expr_build_from_string(fy_path_parse_cfg* pcfg, char* str, size_t len)
+
+    void fy_path_expr_free(fy_path_expr* expr)
+
+    void fy_path_expr_dump(fy_path_expr* expr, fy_diag* diag, fy_error_type errlevel, int level, char* banner)
+
+    cdef enum fy_path_exec_cfg_flags:
+        FYPXCF_QUIET
+        FYPXCF_DISABLE_RECYCLING
+        FYPXCF_DISABLE_ACCELERATORS
+
+    cdef struct fy_path_exec_cfg:
+        fy_path_exec_cfg_flags flags
+        void* userdata
+        fy_diag* diag
+
+    fy_path_exec* fy_path_exec_create(fy_path_exec_cfg* xcfg)
+
+    void fy_path_exec_destroy(fy_path_exec* fypx)
+
+    int fy_path_exec_reset(fy_path_exec* fypx)
+
+    int fy_path_exec_execute(fy_path_exec* fypx, fy_path_expr* expr, fy_node* fyn_start)
+
+    fy_node* fy_path_exec_results_iterate(fy_path_exec* fypx, void** prevp)
+
+    cdef enum fy_token_type:
+        FYTT_NONE
+        FYTT_STREAM_START
+        FYTT_STREAM_END
+        FYTT_VERSION_DIRECTIVE
+        FYTT_TAG_DIRECTIVE
+        FYTT_DOCUMENT_START
+        FYTT_DOCUMENT_END
+        FYTT_BLOCK_SEQUENCE_START
+        FYTT_BLOCK_MAPPING_START
+        FYTT_BLOCK_END
+        FYTT_FLOW_SEQUENCE_START
+        FYTT_FLOW_SEQUENCE_END
+        FYTT_FLOW_MAPPING_START
+        FYTT_FLOW_MAPPING_END
+        FYTT_BLOCK_ENTRY
+        FYTT_FLOW_ENTRY
+        FYTT_KEY
+        FYTT_VALUE
+        FYTT_ALIAS
+        FYTT_ANCHOR
+        FYTT_TAG
+        FYTT_SCALAR
+        FYTT_INPUT_MARKER
+        FYTT_PE_SLASH
+        FYTT_PE_ROOT
+        FYTT_PE_THIS
+        FYTT_PE_PARENT
+        FYTT_PE_MAP_KEY
+        FYTT_PE_SEQ_INDEX
+        FYTT_PE_SEQ_SLICE
+        FYTT_PE_SCALAR_FILTER
+        FYTT_PE_COLLECTION_FILTER
+        FYTT_PE_SEQ_FILTER
+        FYTT_PE_MAP_FILTER
+        FYTT_PE_EVERY_CHILD
+        FYTT_PE_EVERY_CHILD_R
+        FYTT_PE_ALIAS
+        FYTT_PE_SIBLING
+        FYTT_PE_COMMA
+        FYTT_PE_BARBAR
+        FYTT_PE_AMPAMP
+        FYTT_PE_LPAREN
+        FYTT_PE_RPAREN
+
+    bint fy_token_type_is_valid(fy_token_type type)
+
+    bint fy_token_type_is_yaml(fy_token_type type)
+
+    bint fy_token_type_is_content(fy_token_type type)
+
+    bint fy_token_type_is_path_expr(fy_token_type type)
+
+    fy_token_type fy_token_get_type(fy_token* fyt)
+
+    fy_mark* fy_token_start_mark(fy_token* fyt)
+
+    fy_mark* fy_token_end_mark(fy_token* fyt)
+
+    fy_token* fy_scan(fy_parser* fyp)
+
+    void fy_scan_token_free(fy_parser* fyp, fy_token* fyt)
+
+    char* fy_tag_directive_token_prefix0(fy_token* fyt)
+
+    char* fy_tag_directive_token_handle0(fy_token* fyt)
+
+    char* fy_tag_token_handle(fy_token* fyt, size_t* lenp)
+
+    char* fy_tag_token_suffix(fy_token* fyt, size_t* lenp)
+
+    char* fy_tag_token_handle0(fy_token* fyt)
+
+    char* fy_tag_token_suffix0(fy_token* fyt)
+
+    fy_version* fy_version_directive_token_version(fy_token* fyt)
+
+    fy_scalar_style fy_scalar_token_get_style(fy_token* fyt)
+
+    fy_tag* fy_tag_token_tag(fy_token* fyt)
+
+    fy_tag* fy_tag_directive_token_tag(fy_token* fyt)
+
+    fy_token* fy_event_get_token(fy_event* fye)
+
+    fy_token* fy_event_get_anchor_token(fy_event* fye)
+
+    fy_token* fy_event_get_tag_token(fy_event* fye)
+
+    fy_mark* fy_event_start_mark(fy_event* fye)
+
+    fy_mark* fy_event_end_mark(fy_event* fye)
+
+    fy_node_style fy_event_get_node_style(fy_event* fye)
+
+    fy_version* fy_document_start_event_version(fy_event* fye)
+
+    fy_version* fy_document_state_version(fy_document_state* fyds)
+
+    fy_mark* fy_document_state_start_mark(fy_document_state* fyds)
+
+    fy_mark* fy_document_state_end_mark(fy_document_state* fyds)
+
+    bint fy_document_state_version_explicit(fy_document_state* fyds)
+
+    bint fy_document_state_tags_explicit(fy_document_state* fyds)
+
+    bint fy_document_state_start_implicit(fy_document_state* fyds)
+
+    bint fy_document_state_end_implicit(fy_document_state* fyds)
+
+    fy_tag* fy_document_state_tag_directive_iterate(fy_document_state* fyds, void** prevp)
+
+    bint fy_document_state_tag_is_default(fy_document_state* fyds, fy_tag* tag)
+
+    fy_document_state* fy_parser_get_document_state(fy_parser* fyp)
+
+    fy_document_state* fy_document_get_document_state(fy_document* fyd)
+
+    fy_document_state* fy_emitter_get_document_state(fy_emitter* emit)
+
+    fy_event* fy_emit_event_create(fy_emitter* emit, fy_event_type type, ...)
+
+    # fy_event* fy_emit_event_vcreate(fy_emitter* emit, fy_event_type type, va_list ap)
+
+    void fy_emit_event_free(fy_emitter* emit, fy_event* fye)
+
+    fy_event* fy_parse_event_create(fy_parser* fyp, fy_event_type type)
+
+    # fy_event* fy_parse_event_vcreate(fy_parser* fyp, fy_event_type type, va_list ap)

--- a/fyaml/_fyaml.pyx
+++ b/fyaml/_fyaml.pyx
@@ -1,0 +1,1815 @@
+
+import yaml
+import re
+
+def get_version_string():
+    cdef const char *value
+    value = fy_library_version()
+    version = PyUnicode_FromString(value)
+    return version + ".0"
+
+def get_version():
+    cdef int major, minor, patch
+    m = re.match(r"(\d+)\.(\d+)", get_version_string())
+    major = int(m.group(1))
+    minor = int(m.group(2))
+    # we ignore patch number for now (libfyaml uses tags so...
+    patch = 0
+    return (major, minor, patch)
+
+YAMLError = yaml.error.YAMLError
+ReaderError = yaml.reader.ReaderError
+ScannerError = yaml.scanner.ScannerError
+ParserError = yaml.parser.ParserError
+ComposerError = yaml.composer.ComposerError
+ConstructorError = yaml.constructor.ConstructorError
+EmitterError = yaml.emitter.EmitterError
+SerializerError = yaml.serializer.SerializerError
+RepresenterError = yaml.representer.RepresenterError
+
+StreamStartEvent = yaml.events.StreamStartEvent
+StreamEndEvent = yaml.events.StreamEndEvent
+DocumentStartEvent = yaml.events.DocumentStartEvent
+DocumentEndEvent = yaml.events.DocumentEndEvent
+AliasEvent = yaml.events.AliasEvent
+ScalarEvent = yaml.events.ScalarEvent
+SequenceStartEvent = yaml.events.SequenceStartEvent
+SequenceEndEvent = yaml.events.SequenceEndEvent
+MappingStartEvent = yaml.events.MappingStartEvent
+MappingEndEvent = yaml.events.MappingEndEvent
+
+ScalarNode = yaml.nodes.ScalarNode
+SequenceNode = yaml.nodes.SequenceNode
+MappingNode = yaml.nodes.MappingNode
+
+StreamStartToken = yaml.tokens.StreamStartToken
+StreamEndToken = yaml.tokens.StreamEndToken
+DirectiveToken = yaml.tokens.DirectiveToken
+DocumentStartToken = yaml.tokens.DocumentStartToken
+DocumentEndToken = yaml.tokens.DocumentEndToken
+BlockSequenceStartToken = yaml.tokens.BlockSequenceStartToken
+BlockMappingStartToken = yaml.tokens.BlockMappingStartToken
+BlockEndToken = yaml.tokens.BlockEndToken
+FlowSequenceStartToken = yaml.tokens.FlowSequenceStartToken
+FlowMappingStartToken = yaml.tokens.FlowMappingStartToken
+FlowSequenceEndToken = yaml.tokens.FlowSequenceEndToken
+FlowMappingEndToken = yaml.tokens.FlowMappingEndToken
+KeyToken = yaml.tokens.KeyToken
+ValueToken = yaml.tokens.ValueToken
+BlockEntryToken = yaml.tokens.BlockEntryToken
+FlowEntryToken = yaml.tokens.FlowEntryToken
+AliasToken = yaml.tokens.AliasToken
+AnchorToken = yaml.tokens.AnchorToken
+TagToken = yaml.tokens.TagToken
+ScalarToken = yaml.tokens.ScalarToken
+
+cdef class Mark:
+    cdef readonly object name
+    cdef readonly size_t index
+    cdef readonly size_t line
+    cdef readonly size_t column
+    cdef readonly buffer
+    cdef readonly pointer
+
+    def __init__(self, object name, size_t index, size_t line, size_t column,
+            object buffer, object pointer):
+        self.name = name
+        self.index = index
+        self.line = line
+        self.column = column
+        self.buffer = buffer
+        self.pointer = pointer
+
+    def get_snippet(self):
+        return None
+
+    def __str__(self):
+        where = "  in \"%s\", line %d, column %d"   \
+                % (self.name, self.line+1, self.column+1)
+        return where
+
+cdef class FParser:
+
+    cdef fy_parser *parser
+    # we keep two pointers
+    # cython doesn't do anonymous unions so we have to workaround it
+    cdef fy_event *parsed_event
+    cdef _fy_event *_parsed_event
+
+    cdef object stream
+    cdef object stream_name
+    cdef object current_token
+    cdef object current_event
+    cdef object anchors
+    cdef object stream_cache
+    cdef int stream_cache_len
+    cdef int stream_cache_pos
+    cdef int unicode_source
+    cdef int ret
+
+    def __init__(self, stream):
+        cdef is_readable
+        cdef fy_parse_cfg cfg
+
+        memset(&cfg, 0, sizeof(cfg))
+        cfg.search_path = ""
+        cfg.flags = <fy_parse_cfg_flags>(FYPCF_QUIET | FYPCF_DEFAULT_VERSION_1_1 | FYPCF_SLOPPY_FLOW_INDENTATION)
+
+        self.parser = fy_parser_create(&cfg)
+        if self.parser == NULL:
+            raise MemoryError
+
+        self.parsed_event = NULL
+        self._parsed_event = NULL
+
+        # printf("%s: parser created\n", "__init__")
+        is_readable = 1
+        try:
+            stream.read
+        except AttributeError:
+            is_readable = 0
+        self.unicode_source = 0
+        if is_readable:
+            self.stream = stream
+            try:
+                self.stream_name = stream.name
+            except AttributeError:
+                self.stream_name = u'<file>'
+            self.stream_cache = None
+            self.stream_cache_len = 0
+            self.stream_cache_pos = 0
+            ret = fy_parser_set_input_callback(self.parser, <void *>self, input_handler)
+            if ret != 0:
+                raise MemoryError
+        else:
+            if PyUnicode_CheckExact(stream) != 0:
+                stream = PyUnicode_AsUTF8String(stream)
+                self.stream_name = u'<unicode string>'
+                self.unicode_source = 1
+            else:
+                self.stream_name = u'<byte string>'
+            if PyBytes_CheckExact(stream) == 0:
+                raise TypeError(u"a string or stream input is required")
+            self.stream = stream
+            ret = fy_parser_set_string(self.parser, PyBytes_AS_STRING(stream), PyBytes_GET_SIZE(stream))
+            if ret != 0:
+                raise MemoryError
+
+        self.current_token = None
+        self.current_event = None
+        self.anchors = {}
+
+    def __dealloc__(self):
+        fy_parser_event_free(self.parser, self.parsed_event)
+        fy_parser_destroy(self.parser)
+
+    def dispose(self):
+        pass
+
+    cdef object _parser_error(self):
+        # if self.parser.error == YAML_MEMORY_ERROR:
+            printf("_parser_error()\n")
+            return MemoryError
+        # elif self.parser.error == YAML_READER_ERROR:
+        #     return ReaderError(self.stream_name, self.parser.problem_offset,
+        #             self.parser.problem_value, u'?', PyUnicode_FromString(self.parser.problem))
+        # elif self.parser.error == YAML_SCANNER_ERROR    \
+        #         or self.parser.error == YAML_PARSER_ERROR:
+        #     context_mark = None
+        #     problem_mark = None
+        #     if self.parser.context != NULL:
+        #         context_mark = Mark(self.stream_name,
+        #                 self.parser.context_mark.index,
+        #                 self.parser.context_mark.line,
+        #                 self.parser.context_mark.column, None, None)
+        #     if self.parser.problem != NULL:
+        #         problem_mark = Mark(self.stream_name,
+        #                 self.parser.problem_mark.index,
+        #                 self.parser.problem_mark.line,
+        #                 self.parser.problem_mark.column, None, None)
+        #     context = None
+        #     if self.parser.context != NULL:
+        #         context = PyUnicode_FromString(self.parser.context)
+        #     problem = PyUnicode_FromString(self.parser.problem)
+        #     if self.parser.error == YAML_SCANNER_ERROR:
+        #         return ScannerError(context, context_mark, problem, problem_mark)
+        #     else:
+        #         return ParserError(context, context_mark, problem, problem_mark)
+        # raise ValueError(u"no parser error")
+
+    def raw_scan(self):
+        cdef fy_token *token
+        cdef int count
+        cdef fy_token_type type
+
+        count = 0
+        while True:
+            token = fy_scan(self.parser)
+
+            if token == NULL:
+                raise ReaderError(self.stream_name, 0, 0, u'?', PyUnicode_FromString("problem"))
+
+            type = fy_token_get_type(token)
+            # we don't use the token
+            fy_scan_token_free(self.parser, token)
+
+            if type == FYTT_NONE:
+                break
+
+            count = count+1
+
+        return count
+
+    cdef object _scan(self):
+        cdef fy_token *token
+        cdef const fy_mark *start_mark
+        cdef const fy_mark *end_mark
+
+        while True:
+            token = fy_scan(self.parser)
+            if token == NULL:
+                return None
+                # raise ReaderError(self.stream_name, 0, 0, u'?', PyUnicode_FromString("problem"))
+            type = fy_token_get_type(token)
+            if type != FYTT_VALUE:
+                break
+            start_mark = fy_token_start_mark(token)
+            end_mark = fy_token_end_mark(token)
+            # remove from the token stream the NULL value
+            if start_mark[0].input_pos != end_mark[0].input_pos:
+                break
+
+        token_object = self._token_to_object(token)
+        fy_scan_token_free(self.parser, token)
+
+        return token_object
+
+    cdef object _token_to_object(self, fy_token *token):
+        cdef const fy_mark *start_mark
+        cdef const fy_mark *end_mark
+        cdef fy_token_type type
+        cdef const char *text
+        cdef size_t textlen
+        cdef const fy_version *vers
+        cdef const char *prefix
+        cdef const char *handle
+        cdef const char *suffix
+        cdef fy_scalar_style style
+
+        start_mark = fy_token_start_mark(token)
+        end_mark = fy_token_end_mark(token)
+
+        start_markp = Mark(self.stream_name, start_mark[0].input_pos, start_mark[0].line, start_mark[0].column, None, None)
+        end_markp = Mark(self.stream_name, end_mark[0].input_pos, end_mark[0].line, end_mark[0].column, None, None)
+
+        type = fy_token_get_type(token)
+
+        if type == FYTT_NONE:
+            return None
+
+        if type == FYTT_STREAM_START:
+            # libfyaml only does utf-8
+            encoding = u"utf-8"
+            return StreamStartToken(start_markp, end_markp, encoding)
+
+        if type == FYTT_STREAM_END:
+            return StreamEndToken(start_markp, end_markp)
+
+        if type == FYTT_VERSION_DIRECTIVE:
+
+            vers = fy_version_directive_token_version(token)
+            if vers == NULL:
+                raise MemoryError
+            return DirectiveToken(u"YAML", (vers[0].major, vers[0].minor), start_markp, end_markp)
+
+        if type == FYTT_TAG_DIRECTIVE:
+
+            prefix = fy_tag_directive_token_prefix0(token)
+            if prefix == NULL:
+                raise MemoryError
+
+            handle = fy_tag_directive_token_handle0(token)
+            if handle == NULL:
+                raise MemoryError
+
+            prefixp = PyUnicode_FromString(prefix)
+            handlep = PyUnicode_FromString(handle)
+
+            return DirectiveToken(u"TAG", (handlep, prefixp), start_markp, end_markp)
+
+        if type == FYTT_DOCUMENT_START:
+            return DocumentStartToken(start_markp, end_markp)
+
+        if type == FYTT_DOCUMENT_END:
+            return DocumentEndToken(start_markp, end_markp)
+
+        if type == FYTT_BLOCK_SEQUENCE_START:
+            return BlockSequenceStartToken(start_markp, end_markp)
+
+        if type == FYTT_BLOCK_MAPPING_START:
+            return BlockMappingStartToken(start_markp, end_markp)
+
+        if type == FYTT_BLOCK_END:
+            return BlockEndToken(start_markp, end_markp)
+
+        if type == FYTT_FLOW_SEQUENCE_START:
+            return FlowSequenceStartToken(start_markp, end_markp)
+
+        if type == FYTT_FLOW_SEQUENCE_END:
+            return FlowSequenceEndToken(start_markp, end_markp)
+
+        if type == FYTT_FLOW_MAPPING_START:
+            return FlowMappingStartToken(start_markp, end_markp)
+
+        if type == FYTT_FLOW_MAPPING_END:
+            return FlowMappingEndToken(start_markp, end_markp)
+
+        if type == FYTT_BLOCK_ENTRY:
+            return BlockEntryToken(start_markp, end_markp)
+
+        if type == FYTT_FLOW_ENTRY:
+            return FlowEntryToken(start_markp, end_markp)
+
+        if type == FYTT_KEY:
+            return KeyToken(start_markp, end_markp)
+
+        if type == FYTT_VALUE:
+            return ValueToken(start_markp, end_markp)
+
+        if type == FYTT_ALIAS:
+            text = fy_token_get_text0(token)
+            if text == NULL:
+                raise MemoryError
+
+            value = PyUnicode_FromString(text)
+            return AliasToken(value, start_markp, end_markp)
+
+        if type == FYTT_ANCHOR:
+
+            text = fy_token_get_text0(token)
+            if text == NULL:
+                raise MemoryError
+
+            valuep = PyUnicode_FromString(text)
+            return AnchorToken(valuep, start_markp, end_markp)
+
+        if type == FYTT_TAG:
+
+            handle = fy_tag_token_handle0(token)
+            if handle == NULL:
+                raise MemoryError
+
+            suffix = fy_tag_token_suffix0(token)
+            if suffix == NULL:
+                raise MemoryError
+
+            handlep = PyUnicode_FromString(handle)
+            suffixp = PyUnicode_FromString(suffix)
+
+            if suffixp == u'' or suffixp == '':
+                suffixp = handlep
+                handlep = None
+
+            if handlep == u'' or handlep == '':
+                handlep = None
+
+            return TagToken((handlep, suffixp), start_markp, end_markp)
+
+        if type == FYTT_SCALAR:
+
+            text = fy_token_get_text(token, &textlen)
+            if text == NULL:
+                raise MemoryError
+
+            value = PyUnicode_DecodeUTF8(text, textlen, 'strict')
+            plain = False
+            stylep = None
+
+            style = fy_scalar_token_get_style(token)
+
+            if style == FYSS_PLAIN:
+                plain = True
+                # stylep = u'' , plain as None
+            elif style == FYSS_SINGLE_QUOTED:
+                stylep = u'\''
+            elif style == FYSS_DOUBLE_QUOTED:
+                stylep = u'"'
+            elif style == FYSS_LITERAL:
+                stylep = u'|'
+            elif style == FYSS_FOLDED:
+                stylep = u'>'
+
+            return ScalarToken(value, plain, start_markp, end_markp, stylep)
+
+        raise ValueError(u"unknown token type")
+
+    def get_token(self):
+        if self.current_token is not None:
+            value = self.current_token
+            self.current_token = None
+        else:
+            value = self._scan()
+        return value
+
+    def peek_token(self):
+        if self.current_token is None:
+            self.current_token = self._scan()
+        return self.current_token
+
+    def check_token(self, *choices):
+        if self.current_token is None:
+            self.current_token = self._scan()
+        if self.current_token is None:
+            return False
+        if not choices:
+            return True
+        token_class = self.current_token.__class__
+        for choice in choices:
+            if token_class is choice:
+                return True
+        return False
+
+    def raw_parse(self):
+        cdef fy_event *event
+        cdef fy_event_type type
+        cdef int count
+
+        count = 0
+        while True:
+            event = fy_parser_parse(self.parser)
+            if event == NULL:
+                raise ParserError(u"unexpected NULL return from fy_parser_parse (raw_parse)")
+            type = event.type
+            fy_parser_event_free(self.parser, event)
+
+            if type == FYET_NONE:
+                break
+
+            count = count+1
+
+        return count
+
+    cdef object _parse(self):
+        cdef fy_event *event
+
+        event = fy_parser_parse(self.parser)
+        if event == NULL:
+            return None
+            # raise ParserError(u"unexpected NULL return from fy_parser_parse")
+        event_object = self._event_to_object(event)
+        fy_parser_event_free(self.parser, event)
+        return event_object
+
+    cdef object _event_to_object(self, fy_event *event):
+        cdef _fy_event *_event
+        cdef const fy_mark *start_mark
+        cdef const fy_mark *end_mark
+        cdef fy_document_state *fyds
+        cdef const fy_version *vers
+        cdef const fy_tag *tag
+        cdef void *tagiter
+        cdef const char *text
+        cdef size_t textlen
+        cdef fy_event_type type
+        cdef fy_node_style nstyle
+
+        _event = <_fy_event *>event
+
+        start_mark = fy_event_start_mark(event)
+        end_mark = fy_event_end_mark(event)
+
+        if start_mark != NULL:
+            start_markp = Mark(self.stream_name, start_mark[0].input_pos, start_mark[0].line, start_mark[0].column, None, None)
+        else:
+            start_markp = None
+
+        if start_mark != NULL:
+            end_markp = Mark(self.stream_name, end_mark[0].input_pos, end_mark[0].line, end_mark[0].column, None, None)
+        else:
+            end_markp = None
+
+        type = event.type
+
+        if type == FYET_NONE:
+            return None
+
+        if type == FYET_STREAM_START:
+            # libfyaml is utf8 only...
+            encoding = u"utf-8"
+            return StreamStartEvent(start_markp, end_markp, encoding)
+
+        if type == FYET_STREAM_END:
+            return StreamEndEvent(start_markp, end_markp)
+
+        if type == FYET_DOCUMENT_START:
+            explicit = False
+            if _event.data.document_start.implicit == 0:
+                explicit = True
+            fyds = _event.data.document_start.document_state
+
+            version = None
+            if fy_document_state_version_explicit(fyds) == True:
+                vers = fy_document_state_version(fyds)
+                version = (vers[0].major, vers[0].minor)
+
+            tags = {}
+            tagsnr = 0
+            if fy_document_state_tags_explicit(fyds) == True:
+                tagiter = NULL
+                while True:
+                    tag = fy_document_state_tag_directive_iterate(fyds, &tagiter)
+                    if tag == NULL:
+                        break
+                    # skip over default tags
+                    implicit = fy_document_state_tag_is_default(fyds, tag)
+                    if implicit == True:
+                        continue
+
+                    handle = PyUnicode_FromString(tag[0].handle)
+                    prefix = PyUnicode_FromString(tag[0].prefix)
+                    tags[handle] = prefix
+                    tagsnr = tagsnr+1
+
+            # if no tags found, set tags to None
+            if tagsnr == 0:
+                tags = None
+
+            return DocumentStartEvent(start_markp, end_markp, explicit, version, tags)
+
+        if type == FYET_DOCUMENT_END:
+            explicit = False
+            if _event.data.document_end.implicit == 0:
+                explicit = True
+            return DocumentEndEvent(start_markp, end_markp, explicit)
+
+        if type == FYET_ALIAS:
+            text = fy_token_get_text0(_event.data.alias.anchor)
+            if text == NULL:
+                raise MemoryError
+            anchor = PyUnicode_FromString(text)
+            return AliasEvent(anchor, start_markp, end_markp)
+
+        if type == FYET_SCALAR:
+
+            anchor = None
+            if _event.data.scalar.anchor != NULL:
+                text = fy_token_get_text0(_event.data.scalar.anchor)
+                if text == NULL:
+                    raise MemoryError
+                anchor = PyUnicode_FromString(text)
+
+            tagp = None
+            if _event.data.scalar.tag != NULL:
+                text = fy_token_get_text0(_event.data.scalar.tag)
+                if text == NULL:
+                    raise MemoryError
+                tagp = PyUnicode_FromString(text)
+
+            text = fy_token_get_text(_event.data.scalar.value, &textlen)
+            if text == NULL:
+                raise MemoryError
+
+            value = PyUnicode_DecodeUTF8(text, textlen, 'strict')
+
+            stylep = None
+            style = fy_token_scalar_style(_event.data.scalar.value)
+
+            if style == FYSS_PLAIN:
+                stylep = u''
+            elif style == FYSS_SINGLE_QUOTED:
+                stylep = u'\''
+            elif style == FYSS_DOUBLE_QUOTED:
+                stylep = u'"'
+            elif style == FYSS_LITERAL:
+                stylep = u'|'
+            elif style == FYSS_FOLDED:
+                stylep = u'>'
+
+            if (style == FYSS_PLAIN and tagp is None) or tagp == '!':
+                implicit = (True, False)
+            elif tagp is None:
+                implicit = (False, True)
+            else:
+                implicit = (False, False)
+
+            return ScalarEvent(anchor, tagp, implicit, value, start_markp, end_markp, stylep)
+
+        if type == FYET_SEQUENCE_START:
+            anchor = None
+            if _event.data.sequence_start.anchor != NULL:
+                text = fy_token_get_text0(_event.data.sequence_start.anchor)
+                if text == NULL:
+                    raise MemoryError
+                anchor = PyUnicode_FromString(text)
+
+            tagp = None
+            if _event.data.sequence_start.tag != NULL:
+                text = fy_token_get_text0(_event.data.sequence_start.tag)
+                if text == NULL:
+                    raise MemoryError
+                tagp = PyUnicode_FromString(text)
+
+            implicit = (tagp is None or tagp == u'!')
+
+            flow_style = None
+            nstyle = fy_event_get_node_style(event)
+            if nstyle == FYNS_FLOW:
+                flow_style = True
+            elif nstyle == FYNS_BLOCK:
+                flow_style = False
+
+            return SequenceStartEvent(anchor, tagp, implicit, start_markp, end_markp, flow_style)
+
+        if type == FYET_MAPPING_START:
+            anchor = None
+            if _event.data.mapping_start.anchor != NULL:
+                text = fy_token_get_text0(_event.data.mapping_start.anchor)
+                if text == NULL:
+                    raise MemoryError
+                anchor = PyUnicode_FromString(text)
+
+            tagp = None
+            if _event.data.mapping_start.tag != NULL:
+                text = fy_token_get_text0(_event.data.mapping_start.tag)
+                if text == NULL:
+                    raise MemoryError
+                tagp = PyUnicode_FromString(text)
+
+            implicit = (tagp is None or tagp == u'!')
+
+            flow_style = None
+            nstyle = fy_event_get_node_style(event)
+            if nstyle == FYNS_FLOW:
+                flow_style = True
+            elif nstyle == FYNS_BLOCK:
+                flow_style = False
+
+            return MappingStartEvent(anchor, tagp, implicit, start_markp, end_markp, flow_style)
+
+        if type == FYET_SEQUENCE_END:
+            return SequenceEndEvent(start_markp, end_markp)
+
+        if type == FYET_MAPPING_END:
+            return MappingEndEvent(start_markp, end_markp)
+
+        raise ValueError(u"unknown event type")
+
+    def get_event(self):
+        if self.current_event is not None:
+            value = self.current_event
+            self.current_event = None
+        else:
+            value = self._parse()
+        return value
+
+    def peek_event(self):
+        if self.current_event is None:
+            self.current_event = self._parse()
+        return self.current_event
+
+    def check_event(self, *choices):
+        if self.current_event is None:
+            self.current_event = self._parse()
+        if self.current_event is None:
+            return False
+        if not choices:
+            return True
+        event_class = self.current_event.__class__
+        for choice in choices:
+            if event_class is choice:
+                return True
+        return False
+
+    def check_node(self):
+        # printf("check_node:\n")
+        self._parse_next_event()
+        if self.parsed_event.type == FYET_STREAM_START:
+            fy_parser_event_free(self.parser, self.parsed_event)
+            self.parsed_event = NULL
+            self._parsed_event = NULL
+            self._parse_next_event()
+        if self.parsed_event == NULL or self.parsed_event.type == FYET_STREAM_END:
+            return False
+        return True
+
+    def get_node(self):
+        # printf("get_node: _parse_next_event() 1\n")
+        self._parse_next_event()
+        if self.parsed_event.type == FYET_STREAM_END:
+            return None
+
+        # printf("get_node: _parse_next_event() 1\n")
+        self._parse_next_event()
+        if self.parsed_event.type == FYET_STREAM_END:
+            return None
+
+        self._parse_free_event()
+
+        node = self._compose_node(None, None)
+        self.anchors = {}
+
+        self._parse_free_event()
+
+        # printf("get_node: _parse_next_event() 3\n")
+        self._parse_next_event()
+
+        return None
+
+    def get_single_node(self):
+        cdef const fy_mark *start_mark
+
+        # printf("get_single_node: _parse_next_event() 1\n")
+        self._parse_next_event()
+        if self.parsed_event.type != FYET_STREAM_START:
+            raise ComposerError("Parser not starting with stream start")
+        # print "got FYET_STREAM_START"
+        self._parse_free_event()
+
+        document = None
+        # printf("get_single_node: _parse_next_event() 2\n")
+        self._parse_next_event()
+
+        if self.parsed_event.type != FYET_DOCUMENT_START:
+            raise ComposerError("Parser not producing document start")
+        # print "got FYET_DOCUMENT_START"
+        self._parse_free_event()
+
+        node = self._compose_node(None, None)
+        self.anchors = {}
+
+        # printf("get_single_node: _parse_next_event() 3\n")
+        self._parse_next_event()
+        if self.parsed_event.type != FYET_DOCUMENT_END:
+            raise ComposerError("Parser not producing document end")
+        # print "got FYET_DOCUMENT_END"
+        self._parse_free_event()
+
+        # printf("get_single_node: _parse_next_event() 4\n")
+        self._parse_next_event()
+        if self.parsed_event.type == FYET_STREAM_END:
+            # print "got FYET_STREAM_END"
+            self._parse_free_event()
+            return node
+
+        if self.parsed_event.type != FYET_DOCUMENT_START:
+            raise ComposerError("Parser not producing document start (on error)")
+
+        # multi document
+        start_mark = fy_event_start_mark(self.parsed_event)
+        if start_mark != NULL:
+            mark = Mark(self.stream_name, start_mark[0].input_pos, start_mark[0].line, start_mark[0].column, None, None)
+        else:
+            mark = None
+
+        raise ComposerError(u"expected a single document in the stream",
+                document.start_mark, u"but found another document", mark)
+
+    cdef object _compose_node(self, object parent, object index):
+        # printf("_compose_node\n")
+        cdef const char *anchor_str
+        cdef const char *tagstr
+        cdef const fy_mark *start_mark
+        cdef fy_token *anchor_token
+
+        # printf("_compose_node() 1\n")
+        self._parse_next_event()
+        # printf("_compose_node() 1 after\n")
+
+        if self.parsed_event == NULL or self.parsed_event.type == FYET_STREAM_END:
+            # printf("_compose_node() None\n")
+            return None
+
+        if self.parsed_event.type == FYET_ALIAS:
+
+            anchor_str = fy_token_get_text0(self._parsed_event.data.alias.anchor)
+            if anchor_str == NULL:
+                raise MemoryError
+
+            anchor = PyUnicode_FromString(anchor_str)
+
+            if anchor in self.anchors:
+                self._parse_free_event()
+                return self.anchors[anchor]
+
+            start_mark = fy_event_start_mark(self.parsed_event)
+
+            mark = Mark(self.stream_name, start_mark[0].input_pos, start_mark[0].line, start_mark[0].column, None, None)
+            raise ComposerError(None, None, u"found undefined alias", mark)
+
+        # get the anchor (if any)
+        anchor_token = NULL
+        if self.parsed_event.type == FYET_SCALAR:
+            anchor_token = self._parsed_event.data.scalar.anchor
+        elif self.parsed_event.type == FYET_SEQUENCE_START:
+            anchor_token = self._parsed_event.data.sequence_start.anchor
+        elif self.parsed_event.type == FYET_MAPPING_START:
+            anchor_token = self._parsed_event.data.mapping_start.anchor
+
+        # check duplicate anchor
+        if anchor_token != NULL:
+            anchor_str = fy_token_get_text0(anchor_token)
+            if anchor_str == NULL:
+                raise MemoryError
+            anchor = PyUnicode_FromString(anchor_str)
+        else:
+            anchor = None
+
+        if anchor != None and anchor in self.anchors:
+
+            start_mark = fy_event_start_mark(self.parsed_event)
+
+            mark = Mark(self.stream_name,
+                    start_mark[0].input_pos,
+                    start_mark[0].line,
+                    start_mark[0].column,
+                    None, None)
+            raise ComposerError(u"found duplicate anchor; first occurrence",
+                    self.anchors[anchor].start_mark, u"second occurrence", mark)
+
+        # printf("_compose_node(): descend_resolver\n")
+        self.descend_resolver(parent, index)
+        # printf("_compose_node(): descend_resolver out\n")
+
+        if self.parsed_event == NULL:
+            # printf("_compose_node(): self.parsed_event == NULL\n")
+            node = None
+        if self.parsed_event.type == FYET_STREAM_END:
+            # printf("_compose_node(): FYET_STREAM_END\n")
+            none = None
+        if self.parsed_event.type == FYET_SCALAR:
+            # printf("_compose_node(): FYET_SCALAR\n")
+            node = self._compose_scalar_node(anchor)
+        elif self.parsed_event.type == FYET_SEQUENCE_START:
+            # printf("_compose_node(): FYET_SEQUENCE_START\n")
+            node = self._compose_sequence_node(anchor)
+        elif self.parsed_event.type == FYET_MAPPING_START:
+            # printf("_compose_node(): FYET_MAPPING_START\n")
+            node = self._compose_mapping_node(anchor)
+        else:
+            raise ComposerError(u"Unknown event type")
+
+        # printf("_compose_node(): ascend_resolver\n")
+        self.ascend_resolver()
+        # printf("_compose_node(): ascend_resolver end\n")
+        return node
+
+    cdef _compose_scalar_node(self, object anchor):
+        # printf("_compose_scalar_node\n")
+        cdef const fy_mark *start_mark
+        cdef const fy_mark *end_mark
+        cdef fy_mark empty_mark
+        cdef const char *str
+        cdef size_t len
+        cdef const char *tag_str
+        cdef fy_scalar_style style
+
+        # printf("_compose_scalar_node(): before fy_event_start_mark\n")
+        start_mark = fy_event_start_mark(self.parsed_event)
+        # printf("_compose_scalar_node(): after fy_event_start_mark\n")
+        end_mark = fy_event_end_mark(self.parsed_event)
+
+        # printf("_compose_scalar_node(): start_mark=%p end_mark=%p\n", start_mark, end_mark)
+
+        if start_mark == NULL and end_mark == NULL:
+           empty_mark.input_pos = 0
+           empty_mark.line = 0
+           empty_mark.column = 0
+           start_mark = end_mark = &empty_mark
+
+        start_markp = Mark(self.stream_name, start_mark[0].input_pos, start_mark[0].line, start_mark[0].column, None, None)
+        end_markp = Mark(self.stream_name, end_mark[0].input_pos, end_mark[0].line, end_mark[0].column, None, None)
+
+        # printf("_compose_scalar_node(): before fy_token_get_text\n")
+        str = fy_token_get_text(self._parsed_event.data.scalar.value, &len)
+        # printf("_compose_scalar_node(): after fy_token_get_text\n")
+        if str == NULL:
+             # printf("str == NULL\n")
+             raise MemoryError
+
+        # printf("_compose_scalar_node(): before PyUnicode_DecodeUTF8\n")
+        value = PyUnicode_DecodeUTF8(str, len, 'strict')
+        # printf("_compose_scalar_node(): after PyUnicode_DecodeUTF8\n")
+
+        # wtf are those...
+        plain_implicit = False
+        quoted_implicit = False
+
+        if self._parsed_event.data.scalar.tag == NULL:
+            tag = self.resolve(ScalarNode, value, (plain_implicit, quoted_implicit))
+        else:
+            tag_str = fy_token_get_text0(self._parsed_event.data.scalar.tag)
+            if tag_str == NULL:
+                raise MemoryError
+
+            if tag_str[0] == c'!' and tag_str[1] == c'\0':
+                tag = self.resolve(ScalarNode, value, (plain_implicit, quoted_implicit))
+            else:
+                tag = PyUnicode_FromString(tag_str)
+
+        stylep = None
+        style = fy_token_scalar_style(self._parsed_event.data.scalar.value)
+        if style == FYSS_PLAIN:
+            stylep = u''
+        elif style == FYSS_SINGLE_QUOTED:
+            stylep = u'\''
+        elif style == FYSS_DOUBLE_QUOTED:
+            stylep = u'"'
+        elif style == FYSS_LITERAL:
+            stylep = u'|'
+        elif style == FYSS_FOLDED:
+            stylep = u'>'
+
+        node = ScalarNode(tag, value, start_markp, end_markp, stylep)
+
+        if anchor is not None:
+            self.anchors[anchor] = node
+
+        self._parse_free_event()
+        return node
+
+    cdef _compose_sequence_node(self, object anchor):
+        # printf("_compose_sequence_node\n")
+        cdef const fy_mark *start_mark
+        cdef const fy_mark *end_mark
+        cdef fy_node_style nstyle
+        cdef const char *tag_str
+        cdef int index
+
+        start_mark = fy_event_start_mark(self.parsed_event)
+
+        start_markp = Mark(self.stream_name, start_mark[0].input_pos, start_mark[0].line, start_mark[0].column, None, None)
+        implicit = False
+        if self._parsed_event.data.sequence_start.sequence_start == NULL:
+            implicit = True
+
+        if self._parsed_event.data.sequence_start.tag == NULL:
+            tag = self.resolve(SequenceNode, None, implicit)
+        else:
+            tag_str = fy_token_get_text0(self._parsed_event.data.sequence_start.tag)
+            if tag_str == NULL:
+                raise MemoryError
+
+            if tag_str[0] == c'!' and tag_str[1] == c'\0':
+                tag = self.resolve(SequenceNode, None, implicit)
+            else:
+                tag = PyUnicode_FromString(tag_str)
+
+        flow_style = None
+        nstyle = fy_event_get_node_style(self.parsed_event)
+        if nstyle == FYNS_FLOW:
+            flow_style = True
+        elif nstyle == FYNS_BLOCK:
+            flow_style = False
+        value = []
+        node = SequenceNode(tag, value, start_markp, None, flow_style)
+        if anchor is not None:
+            self.anchors[anchor] = node
+
+        self._parse_free_event()
+
+        index = 0
+        self._parse_next_event()
+        while self.parsed_event.type != FYET_SEQUENCE_END:
+            value.append(self._compose_node(node, index))
+            index = index+1
+            self._parse_next_event()
+
+        end_mark = fy_event_end_mark(self.parsed_event)
+
+        node.end_mark = Mark(self.stream_name, end_mark[0].input_pos, end_mark[0].line, end_mark[0].column, None, None)
+
+        self._parse_free_event()
+        return node
+
+    cdef _compose_mapping_node(self, object anchor):
+        # print "_compose_mapping_node"
+        cdef const fy_mark *start_mark
+        cdef const fy_mark *end_mark
+        cdef fy_node_style nstyle
+        cdef const char *tag_str
+        cdef int index
+
+        start_mark = fy_event_start_mark(self.parsed_event)
+
+        start_markp = Mark(self.stream_name, start_mark[0].input_pos, start_mark[0].line, start_mark[0].column, None, None)
+        implicit = False
+        if self._parsed_event.data.mapping_start.mapping_start == NULL:
+            implicit = True
+
+        if self._parsed_event.data.mapping_start.tag == NULL:
+            tag = self.resolve(MappingNode, None, implicit)
+        else:
+            tag_str = fy_token_get_text0(self._parsed_event.data.mapping_start.tag)
+            if tag_str == NULL:
+                raise MemoryError
+
+            if tag_str[0] == c'!' and tag_str[1] == c'\0':
+                tag = self.resolve(MappingNode, None, implicit)
+            else:
+                tag = PyUnicode_FromString(tag_str)
+
+        flow_style = None
+        nstyle = fy_event_get_node_style(self.parsed_event)
+        if nstyle == FYNS_FLOW:
+            flow_style = True
+        elif nstyle == FYNS_BLOCK:
+            flow_style = False
+        value = []
+        node = MappingNode(tag, value, start_markp, None, flow_style)
+        if anchor is not None:
+            self.anchors[anchor] = node
+
+        self._parse_free_event()
+
+        index = 0
+        self._parse_next_event()
+        while self.parsed_event.type != FYET_MAPPING_END:
+            item_key = self._compose_node(node, None)
+            item_value = self._compose_node(node, item_key)
+            value.append((item_key, item_value))
+            self._parse_next_event()
+
+        end_mark = fy_event_end_mark(self.parsed_event)
+
+        node.end_mark = Mark(self.stream_name, end_mark[0].input_pos, end_mark[0].line, end_mark[0].column, None, None)
+
+        self._parse_free_event()
+        return node
+
+    cdef char *_parsed_event_str(self):
+        if self.parsed_event == NULL:
+            return "NULL"
+        elif self.parsed_event.type == FYET_NONE:
+            return "NONE"
+        elif self.parsed_event.type == FYET_STREAM_START:
+            return "STREAM_START"
+        elif self.parsed_event.type == FYET_STREAM_END:
+            return "STREAM_END"
+        elif self.parsed_event.type == FYET_DOCUMENT_START:
+            return "DOCUMENT_START"
+        elif self.parsed_event.type == FYET_DOCUMENT_END:
+            return "DOCUMENT_END"
+        elif self.parsed_event.type == FYET_MAPPING_START:
+            return "MAPPING_START"
+        elif self.parsed_event.type == FYET_MAPPING_END:
+            return "MAPPING_END"
+        elif self.parsed_event.type == FYET_SEQUENCE_START:
+            return "SEQUENCE_START"
+        elif self.parsed_event.type == FYET_SEQUENCE_END:
+            return "SEQUENCE_END"
+        elif self.parsed_event.type == FYET_SCALAR:
+            return "SCALAR"
+        elif self.parsed_event.type == FYET_ALIAS:
+            return "ALIAS"
+
+        return "UNKONWN"
+
+    cdef void _parse_free_event(self):
+        fy_parser_event_free(self.parser, self.parsed_event)
+        self.parsed_event = NULL
+        self._parsed_event = NULL
+
+    cdef int _parse_next_event(self) except 0:
+
+        if self.parsed_event != NULL:
+            return 1
+
+        self.parsed_event = fy_parser_parse(self.parser)
+
+        if self.parsed_event != NULL:
+            self._parsed_event = <_fy_event *>self.parsed_event
+            # if self.parsed_event.type == FYET_STREAM_END:
+            #    printf("_parse_next_event: STREAM_END\n")
+            return 1
+
+        raise ComposerError(u"unexpected NULL return from fy_parser_parse (_parse_next_event)")
+
+cdef ssize_t input_handler(void *user, void *buf, size_t size):
+    cdef FParser parser
+    parser = <FParser>user
+
+    if parser.stream_cache is None:
+        value = parser.stream.read(size)
+        if PyUnicode_CheckExact(value) != 0:
+            value = PyUnicode_AsUTF8String(value)
+            parser.unicode_source = 1
+        if PyBytes_CheckExact(value) == 0:
+            raise TypeError(u"a string value is expected")
+        parser.stream_cache = value
+        parser.stream_cache_pos = 0
+        parser.stream_cache_len = PyBytes_GET_SIZE(value)
+
+    if (parser.stream_cache_len - parser.stream_cache_pos) < <int>size:
+        size = parser.stream_cache_len - parser.stream_cache_pos
+
+    if size > 0:
+        memcpy(buf, PyBytes_AS_STRING(parser.stream_cache) + parser.stream_cache_pos, size)
+    parser.stream_cache_pos += size
+    if parser.stream_cache_pos == parser.stream_cache_len:
+        parser.stream_cache = None
+
+    return size
+
+cdef class FEmitter:
+
+    cdef fy_emitter *emitter
+
+    cdef object stream
+
+    cdef int document_start_implicit
+    cdef int document_end_implicit
+    cdef object use_version
+    cdef object use_tags
+
+    cdef object serialized_nodes
+    cdef object anchors
+    cdef int last_alias_id
+    cdef int closed
+    cdef int dump_unicode
+    cdef object use_encoding
+
+    def __init__(self, stream, canonical=None, indent=None, width=None, allow_unicode=None, line_break=None, encoding=None, explicit_start=None, explicit_end=None, version=None, tags=None):
+        cdef fy_emitter_cfg cfg
+        cdef unsigned int flags
+
+        flags = 0
+
+        memset(&cfg, 0, sizeof(cfg))
+        cfg.flags = FYECF_MODE_ORIGINAL
+        cfg.output = output_handler
+        cfg.userdata = <void *>self
+
+        self.stream = stream
+        self.dump_unicode = 0
+        if hasattr(stream, u'encoding'):
+            self.dump_unicode = 1
+        if encoding != None:
+            self.use_encoding = encoding
+        else:
+            self.use_encoding = u'utf-8'
+        # if canonical:
+        #     yaml_emitter_set_canonical(&self.emitter, 1)
+        if indent is not None:
+            if indent > 9 or indent < 1:
+                raise TypeError(u"Indent is out of range")
+            flags = flags | ((indent & FYECF_INDENT_MASK) << FYECF_INDENT_SHIFT)
+        else:
+            flags = flags | FYECF_INDENT_DEFAULT
+            
+        if width is not None:
+            if width > 255 or width < 1:
+                raise TypeError(u"Width is out of range")
+            flags = flags | ((width & FYECF_WIDTH_MASK) << FYECF_WIDTH_SHIFT)
+        else:
+            flags = flags | FYECF_WIDTH_DEFAULT
+
+        # if allow_unicode:
+        #     yaml_emitter_set_unicode(&self.emitter, 1)
+        # if line_break is not None:
+        #     if line_break == '\r':
+        #         yaml_emitter_set_break(&self.emitter, YAML_CR_BREAK)
+        #     elif line_break == '\n':
+        #         yaml_emitter_set_break(&self.emitter, YAML_LN_BREAK)
+        #     elif line_break == '\r\n':
+        #         yaml_emitter_set_break(&self.emitter, YAML_CRLN_BREAK)
+        if explicit_start:
+            self.document_start_implicit = 0
+        else:
+            self.document_start_implicit = 1
+        if explicit_end:
+            self.document_end_implicit = 0
+        else:
+            self.document_end_implicit = 1
+        self.use_version = version
+        self.use_tags = tags
+
+        cfg.flags = <fy_emitter_cfg_flags>(FYECF_MODE_ORIGINAL | flags)
+        self.emitter = fy_emitter_create(&cfg)
+        if self.emitter == NULL:
+             # printf("emitter: __init(): failed to create emitter()\n")
+             raise MemoryError
+
+        # printf("emitter __init__()\n")
+
+        self.serialized_nodes = {}
+        self.anchors = {}
+        self.last_alias_id = 0
+        self.closed = -1
+
+    def __dealloc__(self):
+        fy_emitter_destroy(self.emitter)
+
+    def dispose(self):
+        pass
+
+    cdef object _emitter_error(self):
+        # if self.emitter.error == YAML_MEMORY_ERROR:
+            # printf("_emitter_error()\n")
+            return MemoryError
+        # elif self.emitter.error == YAML_EMITTER_ERROR:
+        #     problem = PyUnicode_FromString(self.emitter.problem)
+        #     return EmitterError(problem)
+        # raise ValueError(u"no emitter error")
+        # return None
+
+    def emit(self, event_object):
+        # printf("emit()\n")
+        cdef fy_event *event = NULL
+
+        # cdef yaml_encoding_t encoding
+        # cdef yaml_version_directive_t version_directive_value
+        # cdef yaml_version_directive_t *version_directive
+        # cdef yaml_tag_directive_t tag_directives_value[128]
+        # cdef yaml_tag_directive_t *tag_directives_start
+        # cdef yaml_tag_directive_t *tag_directives_end
+        cdef int implicit
+        cdef int plain_implicit
+        cdef int quoted_implicit
+        cdef char *anchor
+        cdef char *tag
+        cdef char *value
+        cdef int length
+        cdef fy_scalar_style scalar_style
+        cdef fy_version vers_tmp
+        cdef fy_node_style node_style
+        cdef fy_version *vers
+        cdef fy_tag **tags
+        cdef fy_tag *tags_arr
+        cdef char *tag_handle
+        cdef char *tag_prefix
+        cdef int idx
+        cdef int tag_count
+
+        event_class = event_object.__class__
+        if event_class is StreamStartEvent:
+            if event_object.encoding != u'utf-8':
+                raise ValueError(u"serializer only supports utf-8 (was " + event_object.encoding + u")")
+
+            event = fy_emit_event_create(self.emitter, FYET_STREAM_START)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is StreamEndEvent:
+
+            event = fy_emit_event_create(self.emitter, FYET_STREAM_END)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is DocumentStartEvent:
+
+            vers = NULL
+            if event_object.version:
+                vers = &vers_tmp
+                vers[0].major = event_object.version[0]
+                vers[0].minor = event_object.version[1]
+
+            tags = NULL
+            tags_arr = NULL
+            if event_object.tags:
+                if len(event_object.tags) > 128:
+                    raise ValueError(u"too many tags")
+
+                tag_count = len(event_object.tags)
+                tags = <fy_tag **>malloc(sizeof(fy_tag *) * (tag_count + 1))
+                if tags == NULL:
+                    raise MemoryError
+
+                tags_arr = <fy_tag *>malloc(sizeof(fy_tag) * tag_count)
+                if tags_arr == NULL:
+                    raise MemoryError
+
+                cache = []
+
+                idx = 0
+                for handle in event_object.tags:
+                    prefix = event_object.tags[handle]
+                    if PyUnicode_CheckExact(handle):
+                        handle = PyUnicode_AsUTF8String(handle)
+                        cache.append(handle)
+                    if not PyBytes_CheckExact(handle):
+                        raise TypeError(u"tag handle must be a string")
+                    tag_handle = PyBytes_AS_STRING(handle)
+
+                    if PyUnicode_CheckExact(prefix):
+                        prefix = PyUnicode_AsUTF8String(prefix)
+                        cache.append(prefix)
+                    if not PyBytes_CheckExact(prefix):
+                        raise TypeError(u"tag prefix must be a string")
+                    tag_prefix = PyBytes_AS_STRING(prefix)
+
+                    tags_arr[idx].handle = tag_handle
+                    tags_arr[idx].prefix = tag_prefix
+                    tags[idx] = &tags_arr[idx]
+                    idx = idx + 1
+
+                tags[idx] = NULL
+
+            if event_object.explicit:
+                implicit = 0
+            else:
+                implicit = 1
+
+            event = fy_emit_event_create(self.emitter, FYET_DOCUMENT_START, implicit, vers, tags)
+
+            if tags != NULL:
+                free(tags)
+
+            if tags_arr != NULL:
+                free(tags_arr)
+
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is DocumentEndEvent:
+            if event_object.explicit:
+                implicit = 0
+            else:
+                implicit = 1
+
+            event = fy_emit_event_create(self.emitter, FYET_DOCUMENT_END, implicit)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is AliasEvent:
+            anchor = NULL
+            anchor_object = event_object.anchor
+            if PyUnicode_CheckExact(anchor_object):
+                anchor_object = PyUnicode_AsUTF8String(anchor_object)
+            if not PyBytes_CheckExact(anchor_object):
+                raise TypeError(u"anchor must be a string")
+            anchor = PyBytes_AS_STRING(anchor_object)
+
+            event = fy_emit_event_create(self.emitter, FYET_ALIAS, anchor)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is ScalarEvent:
+
+            anchor = NULL
+            anchor_object = event_object.anchor
+            if anchor_object is not None:
+                if PyUnicode_CheckExact(anchor_object):
+                    anchor_object = PyUnicode_AsUTF8String(anchor_object)
+                if not PyBytes_CheckExact(anchor_object):
+                    raise TypeError(u"anchor must be a string")
+                anchor = PyBytes_AS_STRING(anchor_object)
+
+            tag = NULL
+            tag_object = event_object.tag
+            if tag_object is not None:
+                if PyUnicode_CheckExact(tag_object):
+                    tag_object = PyUnicode_AsUTF8String(tag_object)
+                if not PyBytes_CheckExact(tag_object):
+                    raise TypeError(u"tag must be a string")
+                tag = PyBytes_AS_STRING(tag_object)
+            value_object = event_object.value
+            if PyUnicode_CheckExact(value_object):
+                value_object = PyUnicode_AsUTF8String(value_object)
+            if not PyBytes_CheckExact(value_object):
+                raise TypeError(u"value must be a string")
+            value = PyBytes_AS_STRING(value_object)
+            length = PyBytes_GET_SIZE(value_object)
+
+            plain_implicit = 0
+            quoted_implicit = 0
+            if event_object.implicit is not None:
+                plain_implicit = event_object.implicit[0]
+                quoted_implicit = event_object.implicit[1]
+
+            style_object = event_object.style
+            scalar_style = FYSS_PLAIN
+            if style_object == "'" or style_object == u"'":
+                scalar_style = FYSS_SINGLE_QUOTED
+            elif style_object == "\"" or style_object == u"\"":
+                scalar_style = FYSS_DOUBLE_QUOTED
+            elif style_object == "|" or style_object == u"|":
+                scalar_style = FYSS_LITERAL
+            elif style_object == ">" or style_object == u">":
+                scalar_style = FYSS_FOLDED
+
+            if plain_implicit != 0 or quoted_implicit != 0:
+                tag = NULL
+
+            event = fy_emit_event_create(self.emitter, FYET_SCALAR, scalar_style, value, length, anchor, tag)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is SequenceStartEvent:
+            anchor = NULL
+            anchor_object = event_object.anchor
+            if anchor_object is not None:
+                if PyUnicode_CheckExact(anchor_object):
+                    anchor_object = PyUnicode_AsUTF8String(anchor_object)
+                if not PyBytes_CheckExact(anchor_object):
+                    raise TypeError(u"anchor must be a string")
+                anchor = PyBytes_AS_STRING(anchor_object)
+            tag = NULL
+            tag_object = event_object.tag
+            if tag_object is not None:
+                if PyUnicode_CheckExact(tag_object):
+                    tag_object = PyUnicode_AsUTF8String(tag_object)
+                if not PyBytes_CheckExact(tag_object):
+                    raise TypeError(u"tag must be a string")
+                tag = PyBytes_AS_STRING(tag_object)
+
+            if event_object.flow_style:
+                node_style = FYNS_FLOW
+            else:
+                node_style = FYNS_BLOCK
+
+            if event_object.implicit:
+                implicit = 1
+            else:
+                implicit = 0
+
+            if implicit != 0:
+                tag = NULL
+
+            event = fy_emit_event_create(self.emitter, FYET_SEQUENCE_START, node_style, NULL, tag)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is SequenceEndEvent:
+            event = fy_emit_event_create(self.emitter, FYET_SEQUENCE_END)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is MappingStartEvent:
+            anchor = NULL
+            anchor_object = event_object.anchor
+            if anchor_object is not None:
+                if PyUnicode_CheckExact(anchor_object):
+                    anchor_object = PyUnicode_AsUTF8String(anchor_object)
+                if not PyBytes_CheckExact(anchor_object):
+                    raise TypeError(u"anchor must be a string")
+                anchor = PyBytes_AS_STRING(anchor_object)
+
+            tag = NULL
+            tag_object = event_object.tag
+            if tag_object is not None:
+                if PyUnicode_CheckExact(tag_object):
+                    tag_object = PyUnicode_AsUTF8String(tag_object)
+                if not PyBytes_CheckExact(tag_object):
+                    raise TypeError(u"tag must be a string")
+                tag = PyBytes_AS_STRING(tag_object)
+
+            if event_object.flow_style:
+                node_style = FYNS_FLOW
+            else:
+                node_style = FYNS_BLOCK
+
+            if event_object.implicit:
+                implicit = 1
+            else:
+                implicit = 0
+
+            event = fy_emit_event_create(self.emitter, FYET_MAPPING_START, node_style, anchor, tag)
+            if event == NULL:
+                raise MemoryError
+
+        elif event_class is MappingEndEvent:
+            event = fy_emit_event_create(self.emitter, FYET_MAPPING_END)
+            if event == NULL:
+                raise MemoryError
+
+        else:
+            raise TypeError(u"invalid event %s" % event_object)
+
+        ret = fy_emit_event(self.emitter, event)
+        if ret != 0:
+            # error = self._emitter_error()
+            # raise error
+            raise MemoryError
+
+        return 1
+
+    def open(self):
+        # printf("open()\n")
+        cdef fy_event *event
+
+        if self.closed == -1:
+            if self.use_encoding != u'utf-8':
+                raise ValueError(u"serializer only supports utf-8 (was " + self.use_encoding + u")")
+
+            event = fy_emit_event_create(self.emitter, FYET_STREAM_START)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+            self.closed = 0
+        elif self.closed == 1:
+            raise SerializerError(u"serializer is closed")
+        else:
+            raise SerializerError(u"serializer is already opened")
+        return None
+
+    def close(self):
+        # printf("close()\n")
+        cdef fy_event *event
+        if self.closed == -1:
+            raise SerializerError(u"serializer is not opened")
+        elif self.closed == 0:
+            event = fy_emit_event_create(self.emitter, FYET_STREAM_END)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+            self.closed = 1
+        return None
+
+    def serialize(self, node):
+        # printf("serialize()\n")
+        cdef fy_event *event
+        cdef fy_version *vers
+        cdef fy_tag **tags
+        cdef fy_tag *tags_arr
+        cdef fy_version vers_tmp
+        cdef char *tag_handle
+        cdef char *tag_prefix
+        cdef int idx
+        cdef int tag_count
+
+        vers = NULL
+        tags = NULL
+        if self.closed == -1:
+            raise SerializerError(u"serializer is not opened")
+        elif self.closed == 1:
+            raise SerializerError(u"serializer is closed")
+        cache = []
+        vers = NULL
+        if self.use_version:
+            vers = &vers_tmp
+            vers[0].major = self.use_version[0]
+            vers[0].minor = self.use_version[1]
+
+        tags = NULL
+        tags_arr = NULL
+        if self.use_tags:
+            if len(self.use_tags) > 128:
+                raise ValueError(u"too many tags")
+
+            tag_count = len(self.use_tags)
+            tags = <fy_tag **>malloc(sizeof(fy_tag *) * (tag_count + 1))
+            if tags == NULL:
+                raise MemoryError
+
+            tags_arr = <fy_tag *>malloc(sizeof(fy_tag) * tag_count)
+            if tags_arr == NULL:
+                raise MemoryError
+
+            idx = 0
+            for handle in self.use_tags:
+                prefix = self.use_tags[handle]
+                if PyUnicode_CheckExact(handle):
+                    handle = PyUnicode_AsUTF8String(handle)
+                    cache.append(handle)
+                if not PyBytes_CheckExact(handle):
+                    raise TypeError(u"tag handle must be a string")
+                tag_handle = PyBytes_AS_STRING(handle)
+
+                if PyUnicode_CheckExact(prefix):
+                    prefix = PyUnicode_AsUTF8String(prefix)
+                    cache.append(prefix)
+                if not PyBytes_CheckExact(prefix):
+                    raise TypeError(u"tag prefix must be a string")
+                tag_prefix = PyBytes_AS_STRING(prefix)
+
+                tags_arr[idx].handle = tag_handle
+                tags_arr[idx].prefix = tag_prefix
+                tags[idx] = &tags_arr[idx]
+                idx = idx + 1
+
+            tags[idx] = NULL
+
+        event = fy_emit_event_create(self.emitter, FYET_DOCUMENT_START, self.document_start_implicit, vers, tags)
+
+        if vers != NULL:
+            free(vers)
+
+        if tags != NULL:
+            free(tags)
+
+        if tags_arr != NULL:
+            free(tags_arr)
+
+        if event == NULL:
+            raise MemoryError
+        ret = fy_emit_event(self.emitter, event)
+        if ret != 0:
+            raise MemoryError
+
+        self._anchor_node(node)
+        self._serialize_node(node, None, None)
+
+        event = fy_emit_event_create(self.emitter, FYET_DOCUMENT_END, self.document_end_implicit)
+        if event == NULL:
+            raise MemoryError
+        ret = fy_emit_event(self.emitter, event)
+        if ret != 0:
+            raise MemoryError
+
+        self.serialized_nodes = {}
+        self.anchors = {}
+        self.last_alias_id = 0
+
+        return None
+
+    cdef int _anchor_node(self, object node) except 0:
+        # printf("_anchor_node()\n")
+        if node in self.anchors:
+            if self.anchors[node] is None:
+                self.last_alias_id = self.last_alias_id+1
+                self.anchors[node] = u"id%03d" % self.last_alias_id
+        else:
+            self.anchors[node] = None
+            node_class = node.__class__
+            if node_class is SequenceNode:
+                for item in node.value:
+                    self._anchor_node(item)
+            elif node_class is MappingNode:
+                for key, value in node.value:
+                    self._anchor_node(key)
+                    self._anchor_node(value)
+        return 1
+
+    cdef int _serialize_node(self, object node, object parent, object index) except 0:
+        # printf("_serialize_node()\n")
+        cdef fy_event *event
+        cdef char *anchor
+        # cdef yaml_event_t event
+        # cdef int implicit
+        # cdef int plain_implicit
+        # cdef int quoted_implicit
+        # cdef char *tag
+        # cdef char *value
+        # cdef int length
+        # cdef int item_index
+        cdef fy_scalar_style scalar_style
+        cdef fy_node_style node_style
+        # cdef yaml_sequence_style_t sequence_style
+        # cdef yaml_mapping_style_t mapping_style
+
+        anchor_object = self.anchors[node]
+        anchor = NULL
+        if anchor_object is not None:
+            if PyUnicode_CheckExact(anchor_object):
+                anchor_object = PyUnicode_AsUTF8String(anchor_object)
+            if not PyBytes_CheckExact(anchor_object):
+                raise TypeError(u"anchor must be a string")
+            anchor = PyBytes_AS_STRING(anchor_object)
+
+        if node in self.serialized_nodes:
+            event = fy_emit_event_create(self.emitter, FYET_ALIAS, anchor)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+
+            return 1
+
+        node_class = node.__class__
+        self.serialized_nodes[node] = True
+        self.descend_resolver(parent, index)
+
+        if node_class is ScalarNode:
+            plain_implicit = 0
+            quoted_implicit = 0
+            tag_object = node.tag
+            if self.resolve(ScalarNode, node.value, (True, False)) == tag_object:
+                plain_implicit = 1
+            if self.resolve(ScalarNode, node.value, (False, True)) == tag_object:
+                quoted_implicit = 1
+            tag = NULL
+            if tag_object is not None:
+                if PyUnicode_CheckExact(tag_object):
+                    tag_object = PyUnicode_AsUTF8String(tag_object)
+                if not PyBytes_CheckExact(tag_object):
+                    raise TypeError(u"tag must be a string")
+                tag = PyBytes_AS_STRING(tag_object)
+            value_object = node.value
+            if PyUnicode_CheckExact(value_object):
+                value_object = PyUnicode_AsUTF8String(value_object)
+            if not PyBytes_CheckExact(value_object):
+                raise TypeError(u"value must be a string")
+            value = PyBytes_AS_STRING(value_object)
+            length = PyBytes_GET_SIZE(value_object)
+            style_object = node.style
+
+            scalar_style = FYSS_PLAIN
+            if style_object == "'" or style_object == u"'":
+                scalar_style = FYSS_SINGLE_QUOTED
+            elif style_object == "\"" or style_object == u"\"":
+                scalar_style = FYSS_DOUBLE_QUOTED
+            elif style_object == "|" or style_object == u"|":
+                scalar_style = FYSS_LITERAL
+            elif style_object == ">" or style_object == u">":
+                scalar_style = FYSS_FOLDED
+
+            # printf("_serialize_node() - tag=%s plain_implicit=%d quoted_implicit=%d\n", tag, plain_implicit, quoted_implicit)
+
+            if plain_implicit != 0 or quoted_implicit != 0:
+                tag = NULL
+
+            event = fy_emit_event_create(self.emitter, FYET_SCALAR, scalar_style, value, length, anchor, tag)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+
+        elif node_class is SequenceNode:
+            tag_object = node.tag
+            if self.resolve(SequenceNode, node.value, True) == tag_object:
+                implicit = 1
+            else:
+                implicit = 0
+            tag = NULL
+            if tag_object is not None:
+                if PyUnicode_CheckExact(tag_object):
+                    tag_object = PyUnicode_AsUTF8String(tag_object)
+                if not PyBytes_CheckExact(tag_object):
+                    raise TypeError(u"tag must be a string")
+                tag = PyBytes_AS_STRING(tag_object)
+
+            if node.flow_style:
+                node_style = FYNS_FLOW
+            else:
+                node_style = FYNS_BLOCK
+
+            if implicit != 0:
+                tag = NULL
+
+            event = fy_emit_event_create(self.emitter, FYET_SEQUENCE_START, node_style, anchor, tag)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+
+            item_index = 0
+            for item in node.value:
+                self._serialize_node(item, node, item_index)
+                item_index = item_index+1
+
+            event = fy_emit_event_create(self.emitter, FYET_SEQUENCE_END)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+
+        elif node_class is MappingNode:
+            tag_object = node.tag
+            if self.resolve(MappingNode, node.value, True) == tag_object:
+                implicit = 1
+            else:
+                implicit = 0
+            tag = NULL
+            if tag_object is not None:
+                if PyUnicode_CheckExact(tag_object):
+                    tag_object = PyUnicode_AsUTF8String(tag_object)
+                if not PyBytes_CheckExact(tag_object):
+                    raise TypeError(u"tag must be a string")
+                tag = PyBytes_AS_STRING(tag_object)
+
+            if node.flow_style:
+                node_style = FYNS_FLOW
+            else:
+                node_style = FYNS_BLOCK
+
+            if implicit != 0:
+                tag = NULL
+
+            event = fy_emit_event_create(self.emitter, FYET_MAPPING_START, node_style, anchor, tag)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+
+            for item_key, item_value in node.value:
+                self._serialize_node(item_key, node, None)
+                self._serialize_node(item_value, node, item_key)
+
+            event = fy_emit_event_create(self.emitter, FYET_MAPPING_END)
+            if event == NULL:
+                raise MemoryError
+            ret = fy_emit_event(self.emitter, event)
+            if ret != 0:
+                raise MemoryError
+
+        self.ascend_resolver()
+        return 1
+
+cdef int output_handler(fy_emitter *emit, fy_emitter_write_type type, const char *str, int len, void *data):
+    cdef FEmitter emitter
+    emitter = <FEmitter>data
+    if emitter.dump_unicode == 0:
+        value = PyBytes_FromStringAndSize(str, len)
+    else:
+        value = PyUnicode_DecodeUTF8(str, len, 'strict')
+    emitter.stream.write(value)
+    return len

--- a/lib/_fyaml/__init__.py
+++ b/lib/_fyaml/__init__.py
@@ -1,0 +1,31 @@
+# This is a stub package designed to roughly emulate the _yaml
+# extension module, which previously existed as a standalone module
+# and has been moved into the `yaml` package namespace.
+# It does not perfectly mimic its old counterpart, but should get
+# close enough for anyone who's relying on it even when they shouldn't.
+import yaml
+
+# in some circumstances, the yaml module we imoprted may be from a different version, so we need
+# to tread carefully when poking at it here (it may not have the attributes we expect)
+if not getattr(yaml, '__with_libfyaml__', False):
+    from sys import version_info
+
+    exc = ModuleNotFoundError if version_info >= (3, 6) else ImportError
+    raise exc("No module named '_fyaml'")
+else:
+    from yaml._fyaml import *
+    import warnings
+    warnings.warn(
+        ' To use the libfyaml-based parser and emitter, import from `yaml`:'
+        ' `from yaml import FLoader as Loader, FDumper as Dumper`.',
+        DeprecationWarning
+    )
+    del warnings
+    # Don't `del yaml` here because yaml is actually an existing
+    # namespace member of _yaml.
+
+__name__ = '_fyaml'
+# If the module is top-level (i.e. not a part of any specific package)
+# then the attribute should be set to ''.
+# https://docs.python.org/3.8/library/types.html
+__package__ = ''

--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -15,6 +15,12 @@ try:
 except ImportError:
     __with_libyaml__ = False
 
+try:
+    from .fyaml import *
+    __with_libfyaml__ = True
+except ImportError:
+    __with_libfyaml__ = False
+
 import io
 
 #------------------------------------------------------------------------------

--- a/lib/yaml/fyaml.py
+++ b/lib/yaml/fyaml.py
@@ -1,0 +1,101 @@
+
+__all__ = [
+    'FBaseLoader', 'FSafeLoader', 'FFullLoader', 'FUnsafeLoader', 'FLoader',
+    'FBaseDumper', 'FSafeDumper', 'FDumper'
+]
+
+from yaml._fyaml import FParser, FEmitter
+
+from .constructor import *
+
+from .serializer import *
+from .representer import *
+
+from .resolver import *
+
+class FBaseLoader(FParser, BaseConstructor, BaseResolver):
+
+    def __init__(self, stream):
+        FParser.__init__(self, stream)
+        BaseConstructor.__init__(self)
+        BaseResolver.__init__(self)
+
+class FSafeLoader(FParser, SafeConstructor, Resolver):
+
+    def __init__(self, stream):
+        FParser.__init__(self, stream)
+        SafeConstructor.__init__(self)
+        Resolver.__init__(self)
+
+class FFullLoader(FParser, FullConstructor, Resolver):
+
+    def __init__(self, stream):
+        FParser.__init__(self, stream)
+        FullConstructor.__init__(self)
+        Resolver.__init__(self)
+
+class FUnsafeLoader(FParser, UnsafeConstructor, Resolver):
+
+    def __init__(self, stream):
+        FParser.__init__(self, stream)
+        UnsafeConstructor.__init__(self)
+        Resolver.__init__(self)
+
+class FLoader(FParser, Constructor, Resolver):
+
+    def __init__(self, stream):
+        FParser.__init__(self, stream)
+        Constructor.__init__(self)
+        Resolver.__init__(self)
+
+class FBaseDumper(FEmitter, BaseRepresenter, BaseResolver):
+
+    def __init__(self, stream,
+            default_style=None, default_flow_style=False,
+            canonical=None, indent=None, width=None,
+            allow_unicode=None, line_break=None,
+            encoding=None, explicit_start=None, explicit_end=None,
+            version=None, tags=None, sort_keys=True):
+        FEmitter.__init__(self, stream, canonical=canonical,
+                indent=indent, width=width, encoding=encoding,
+                allow_unicode=allow_unicode, line_break=line_break,
+                explicit_start=explicit_start, explicit_end=explicit_end,
+                version=version, tags=tags)
+        Representer.__init__(self, default_style=default_style,
+                default_flow_style=default_flow_style, sort_keys=sort_keys)
+        Resolver.__init__(self)
+
+class FSafeDumper(FEmitter, SafeRepresenter, Resolver):
+
+    def __init__(self, stream,
+            default_style=None, default_flow_style=False,
+            canonical=None, indent=None, width=None,
+            allow_unicode=None, line_break=None,
+            encoding=None, explicit_start=None, explicit_end=None,
+            version=None, tags=None, sort_keys=True):
+        FEmitter.__init__(self, stream, canonical=canonical,
+                indent=indent, width=width, encoding=encoding,
+                allow_unicode=allow_unicode, line_break=line_break,
+                explicit_start=explicit_start, explicit_end=explicit_end,
+                version=version, tags=tags)
+        SafeRepresenter.__init__(self, default_style=default_style,
+                default_flow_style=default_flow_style, sort_keys=sort_keys)
+        Resolver.__init__(self)
+
+class FDumper(FEmitter, Serializer, Representer, Resolver):
+
+    def __init__(self, stream,
+            default_style=None, default_flow_style=False,
+            canonical=None, indent=None, width=None,
+            allow_unicode=None, line_break=None,
+            encoding=None, explicit_start=None, explicit_end=None,
+            version=None, tags=None, sort_keys=True):
+        FEmitter.__init__(self, stream, canonical=canonical,
+                indent=indent, width=width, encoding=encoding,
+                allow_unicode=allow_unicode, line_break=line_break,
+                explicit_start=explicit_start, explicit_end=explicit_end,
+                version=version, tags=tags)
+        Representer.__init__(self, default_style=default_style,
+                default_flow_style=default_flow_style, sort_keys=sort_keys)
+        Resolver.__init__(self)
+

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,22 @@ int main(void) {
 }
 """
 
+LIBFYAML_CHECK = """
+#include <libfyaml.h>
+
+int main(void) {
+    struct fy_parse_cfg cfg;
+    struct fy_parser *fyp;
+
+    memset(&cfg, 0, sizeof(cfg));
+    fyp = fy_parser_create(&cfg);
+    fy_parser_destroy(fyp);
+
+    return 0;
+}
+"""
+
+
 
 import sys, os, os.path, platform, warnings
 
@@ -283,6 +299,10 @@ if __name__ == '__main__':
             Extension('yaml._yaml', ['yaml/_yaml.pyx'],
                 'libyaml', "LibYAML bindings", LIBYAML_CHECK,
                 libraries=['yaml']),
+            Extension('yaml._fyaml', ['fyaml/_fyaml.pyx'],
+                'libfyaml', "libfyaml bindings", LIBYAML_CHECK,
+                libraries=['fyaml-0.7'],
+                language="c"),
         ],
 
         distclass=Distribution,


### PR DESCRIPTION
This module implements an additional C based backend based on
libfyaml.

For the initial drop the goal is to have something as similar as
possible to the libyaml backend, where this is possible.

It is still in an experimental phase, so things like error
support do not work yet.

In order to use replace the capital C with an F on each case,
i.e. instead of CLoader use FLoader, CDumper use FDumper etc.

Signed-off-by: Pantelis Antoniou <pantelis.antoniou@konsulko.com>