### PR TITLE
Set Cython compiler directive language_level=3

### DIFF
--- a/yaml/_yaml.pyx
+++ b/yaml/_yaml.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3
 
 import yaml
 


### PR DESCRIPTION
Set `language_level` to Python3 explicitly.

> language_level – The source language level to use: 2 or 3.
> The default is to use the language level of the current
> Python runtime for .py files and Py2 for .pyx files.

Closes #409.