### PR TITLE
Add strict_whitespace implementation for cleaner multiline scalars

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -217,7 +217,7 @@ def dump_all(documents, stream=None, Dumper=Dumper,
         canonical=None, indent=None, width=None,
         allow_unicode=None, line_break=None,
         encoding=None, explicit_start=None, explicit_end=None,
-        version=None, tags=None, sort_keys=True):
+        version=None, tags=None, sort_keys=True, strict_whitespace=True):
     """
     Serialize a sequence of Python objects into a YAML stream.
     If stream is None, return the produced string instead.
@@ -234,7 +234,7 @@ def dump_all(documents, stream=None, Dumper=Dumper,
             canonical=canonical, indent=indent, width=width,
             allow_unicode=allow_unicode, line_break=line_break,
             encoding=encoding, version=version, tags=tags,
-            explicit_start=explicit_start, explicit_end=explicit_end, sort_keys=sort_keys)
+            explicit_start=explicit_start, explicit_end=explicit_end, sort_keys=sort_keys, strict_whitespace=strict_whitespace)
     try:
         dumper.open()
         for data in documents:

--- a/lib/yaml/dumper.py
+++ b/lib/yaml/dumper.py
@@ -13,7 +13,7 @@ class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
-            version=None, tags=None, sort_keys=True):
+            version=None, tags=None, sort_keys=True, strict_whitespace=True):
         Emitter.__init__(self, stream, canonical=canonical,
                 indent=indent, width=width,
                 allow_unicode=allow_unicode, line_break=line_break)
@@ -31,10 +31,10 @@ class SafeDumper(Emitter, Serializer, SafeRepresenter, Resolver):
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
-            version=None, tags=None, sort_keys=True):
+            version=None, tags=None, sort_keys=True, strict_whitespace=True):
         Emitter.__init__(self, stream, canonical=canonical,
                 indent=indent, width=width,
-                allow_unicode=allow_unicode, line_break=line_break)
+                allow_unicode=allow_unicode, line_break=line_break, strict_whitespace=strict_whitespace)
         Serializer.__init__(self, encoding=encoding,
                 explicit_start=explicit_start, explicit_end=explicit_end,
                 version=version, tags=tags)
@@ -49,10 +49,10 @@ class Dumper(Emitter, Serializer, Representer, Resolver):
             canonical=None, indent=None, width=None,
             allow_unicode=None, line_break=None,
             encoding=None, explicit_start=None, explicit_end=None,
-            version=None, tags=None, sort_keys=True):
+            version=None, tags=None, sort_keys=True, strict_whitespace=True):
         Emitter.__init__(self, stream, canonical=canonical,
                 indent=indent, width=width,
-                allow_unicode=allow_unicode, line_break=line_break)
+                allow_unicode=allow_unicode, line_break=line_break, strict_whitespace=strict_whitespace)
         Serializer.__init__(self, encoding=encoding,
                 explicit_start=explicit_start, explicit_end=explicit_end,
                 version=version, tags=tags)


### PR DESCRIPTION
Hi - this is an attempt to (optionally) make output of multiline scalars more readable by eliminating the backslash character at the beginning and end of lines where possible. Some of these issues were raised in https://github.com/yaml/pyyaml/issues/402.