### PR TITLE
WIP keep PyYAML build working on Cython3.0.0a10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython~=3.0a"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,11 @@ if 'sdist' in sys.argv or os.environ.get('PYYAML_FORCE_CYTHON') == '1':
     with_cython = True
 try:
     from Cython.Distutils.extension import Extension as _Extension
-    from Cython.Distutils import build_ext as _build_ext
+
+    try:
+        from Cython.Distutils.old_build_ext import old_build_ext as _build_ext
+    except ImportError:
+        from Cython.Distutils import build_ext as _build_ext
     with_cython = True
 except ImportError:
     if with_cython:


### PR DESCRIPTION
fixes #601 

* Cython 3.0 changes its build_ext command base class to one that's incompatible with pyyaml's subclass
* temporarily force use of Cython3's `old_build_ext` compatibility class if present
