### PR TITLE
Added exception handling in setup.py if pathlib is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,14 @@ int main(void) {
 }
 """
 
-
-import sys, os, os.path, pathlib, platform, shutil, tempfile, warnings
+import sys, os, os.path, platform, shutil, tempfile, warnings
+try:
+    import pathlib
+except ImportError:
+    try:
+        import pathlib2 as pathlib
+    except ImportError:
+        raise ImportError("Missing pathlib and pathlib2, please install one to use this library.")
 
 # for newer setuptools, enable the embedded distutils before importing setuptools/distutils to avoid warnings
 os.environ['SETUPTOOLS_USE_DISTUTILS'] = 'local'


### PR DESCRIPTION
Systems that do not have pathlib installed will not work with pyyaml. I have added a small piece of code that allows for pyyaml to be installed on systems that use pathlib2, which is more actively maintained.