### PR TITLE
Add a `value` builtin constructor to handle the `=` sign

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -476,8 +476,13 @@ SafeConstructor.add_constructor(
         'tag:yaml.org,2002:map',
         SafeConstructor.construct_yaml_map)
 
+SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:value',
+        SafeConstructor.construct_yaml_str)
+
 SafeConstructor.add_constructor(None,
         SafeConstructor.construct_undefined)
+
 
 class FullConstructor(SafeConstructor):
     # 'extend' is blacklisted because it is used by


### PR DESCRIPTION
fixes #89 

There's an alternative fix, we can remove the `implicit_loader` from `resolver.py` instead of mapping `'tag:yaml.org,2002:value'` to the string resolver.