### PR TITLE
Replace import * with explicit imports

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -1,16 +1,73 @@
-
-from .error import *
-
-from .tokens import *
-from .events import *
-from .nodes import *
-
-from .loader import *
-from .dumper import *
+"""
+PyYAML
+------
+"""
 
 __version__ = '6.0'
+
+__dev__ = """
+# Run to autogenerate static imports that mimic `import *`
+mkinit --nomods --relative ./lib/yaml/ --diff
+mkinit --nomods --relative ./lib/yaml/ --write
+"""
+
+__submodules__ = {
+    'error': None,
+    'tokens': None,
+    'events': None,
+    'nodes': None,
+    'loader': None,
+    'dumper': None,
+}
+
+# <AUTOGEN_INIT>
+from .error import (Mark, MarkedYAMLError, YAMLError,)
+from .tokens import (AliasToken, AnchorToken, BlockEndToken, BlockEntryToken,
+                     BlockMappingStartToken, BlockSequenceStartToken,
+                     DirectiveToken, DocumentEndToken, DocumentStartToken,
+                     FlowEntryToken, FlowMappingEndToken,
+                     FlowMappingStartToken, FlowSequenceEndToken,
+                     FlowSequenceStartToken, KeyToken, ScalarToken,
+                     StreamEndToken, StreamStartToken, TagToken, Token,
+                     ValueToken,)
+from .events import (AliasEvent, CollectionEndEvent, CollectionStartEvent,
+                     DocumentEndEvent, DocumentStartEvent, Event,
+                     MappingEndEvent, MappingStartEvent, NodeEvent,
+                     ScalarEvent, SequenceEndEvent, SequenceStartEvent,
+                     StreamEndEvent, StreamStartEvent,)
+from .nodes import (CollectionNode, MappingNode, Node, ScalarNode,
+                    SequenceNode,)
+from .loader import (BaseLoader, FullLoader, Loader, SafeLoader, UnsafeLoader,)
+from .dumper import (BaseDumper, Dumper, SafeDumper,)
+
+__all__ = ['AliasEvent', 'AliasToken', 'AnchorToken', 'BaseDumper',
+           'BaseLoader', 'BlockEndToken', 'BlockEntryToken',
+           'BlockMappingStartToken', 'BlockSequenceStartToken',
+           'CollectionEndEvent', 'CollectionNode', 'CollectionStartEvent',
+           'DirectiveToken', 'DocumentEndEvent', 'DocumentEndToken',
+           'DocumentStartEvent', 'DocumentStartToken', 'Dumper', 'Event',
+           'FlowEntryToken', 'FlowMappingEndToken', 'FlowMappingStartToken',
+           'FlowSequenceEndToken', 'FlowSequenceStartToken', 'FullLoader',
+           'KeyToken', 'Loader', 'MappingEndEvent', 'MappingNode',
+           'MappingStartEvent', 'Mark', 'MarkedYAMLError', 'Node', 'NodeEvent',
+           'SafeDumper', 'SafeLoader', 'ScalarEvent', 'ScalarNode',
+           'ScalarToken', 'SequenceEndEvent', 'SequenceNode',
+           'SequenceStartEvent', 'StreamEndEvent', 'StreamEndToken',
+           'StreamStartEvent', 'StreamStartToken', 'TagToken', 'Token',
+           'UnsafeLoader', 'ValueToken', 'YAMLError', 'YAMLObject',
+           'YAMLObjectMetaclass', 'add_constructor', 'add_implicit_resolver',
+           'add_multi_constructor', 'add_multi_representer',
+           'add_path_resolver', 'add_representer', 'compose', 'compose_all',
+           'dump', 'dump_all', 'emit', 'full_load', 'full_load_all', 'load',
+           'load_all', 'parse', 'safe_dump', 'safe_dump_all', 'safe_load',
+           'safe_load_all', 'scan', 'serialize', 'serialize_all',
+           'unsafe_load', 'unsafe_load_all', 'warnings']
+# </AUTOGEN_INIT>
+
+
 try:
-    from .cyaml import *
+    from yaml.cyaml import (CBaseDumper, CBaseLoader, CDumper, CFullLoader,
+                            CLoader, CSafeDumper, CSafeLoader, CUnsafeLoader,)
     __with_libyaml__ = True
 except ImportError:
     __with_libyaml__ = False
@@ -387,4 +444,3 @@ class YAMLObject(metaclass=YAMLObjectMetaclass):
         """
         return dumper.represent_yaml_object(cls.yaml_tag, data, cls,
                 flow_style=cls.yaml_flow_style)
-

--- a/lib/yaml/composer.py
+++ b/lib/yaml/composer.py
@@ -2,8 +2,13 @@
 __all__ = ['Composer', 'ComposerError']
 
 from .error import MarkedYAMLError
-from .events import *
-from .nodes import *
+from .events import (AliasEvent, CollectionEndEvent, CollectionStartEvent,
+                     DocumentEndEvent, DocumentStartEvent, Event,
+                     MappingEndEvent, MappingStartEvent, NodeEvent,
+                     ScalarEvent, SequenceEndEvent, SequenceStartEvent,
+                     StreamEndEvent, StreamStartEvent,)
+from .nodes import (CollectionNode, MappingNode, Node, ScalarNode,
+                    SequenceNode,)
 
 class ComposerError(MarkedYAMLError):
     pass

--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -8,8 +8,8 @@ __all__ = [
     'ConstructorError'
 ]
 
-from .error import *
-from .nodes import *
+from .error import (Mark, MarkedYAMLError, YAMLError,)
+from .nodes import (Node, ScalarNode, CollectionNode, SequenceNode, MappingNode)
 
 import collections.abc, datetime, base64, binascii, re, sys, types
 

--- a/lib/yaml/cyaml.py
+++ b/lib/yaml/cyaml.py
@@ -6,12 +6,15 @@ __all__ = [
 
 from yaml._yaml import CParser, CEmitter
 
-from .constructor import *
+from yaml.constructor import (BaseConstructor, Constructor, ConstructorError,
+                              FullConstructor, SafeConstructor,
+                              UnsafeConstructor,)
 
-from .serializer import *
-from .representer import *
+from .serializer import (Serializer, SerializerError,)
+from .representer import (BaseRepresenter, Representer, RepresenterError,
+                          SafeRepresenter,)
 
-from .resolver import *
+from .resolver import (BaseResolver, Resolver,)
 
 class CBaseLoader(CParser, BaseConstructor, BaseResolver):
 

--- a/lib/yaml/dumper.py
+++ b/lib/yaml/dumper.py
@@ -1,10 +1,11 @@
 
 __all__ = ['BaseDumper', 'SafeDumper', 'Dumper']
 
-from .emitter import *
-from .serializer import *
-from .representer import *
-from .resolver import *
+from .emitter import (Emitter, EmitterError,)
+from .serializer import (Serializer, SerializerError,)
+from .representer import (BaseRepresenter, Representer, RepresenterError,
+                          SafeRepresenter,)
+from .resolver import (BaseResolver, Resolver,)
 
 class BaseDumper(Emitter, Serializer, BaseRepresenter, BaseResolver):
 

--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -9,7 +9,12 @@
 __all__ = ['Emitter', 'EmitterError']
 
 from .error import YAMLError
-from .events import *
+from .events import (AliasEvent, CollectionEndEvent, CollectionStartEvent,
+                     DocumentEndEvent, DocumentStartEvent, Event,
+                     MappingEndEvent, MappingStartEvent, NodeEvent,
+                     ScalarEvent, SequenceEndEvent, SequenceStartEvent,
+                     StreamEndEvent, StreamStartEvent,)
+
 
 class EmitterError(YAMLError):
     pass

--- a/lib/yaml/loader.py
+++ b/lib/yaml/loader.py
@@ -1,12 +1,13 @@
 
 __all__ = ['BaseLoader', 'FullLoader', 'SafeLoader', 'Loader', 'UnsafeLoader']
 
-from .reader import *
-from .scanner import *
-from .parser import *
-from .composer import *
-from .constructor import *
-from .resolver import *
+from .reader import (Reader, ReaderError,)
+from .scanner import (Scanner, ScannerError,)
+from .parser import (Parser, ParserError,)
+from .composer import (Composer, ComposerError,)
+from .constructor import (BaseConstructor, Constructor, ConstructorError,
+                          FullConstructor, SafeConstructor, UnsafeConstructor,)
+from .resolver import (BaseResolver, Resolver,)
 
 class BaseLoader(Reader, Scanner, Parser, Composer, BaseConstructor, BaseResolver):
 

--- a/lib/yaml/parser.py
+++ b/lib/yaml/parser.py
@@ -62,9 +62,20 @@
 __all__ = ['Parser', 'ParserError']
 
 from .error import MarkedYAMLError
-from .tokens import *
-from .events import *
-from .scanner import *
+from .tokens import (AliasToken, AnchorToken, BlockEndToken, BlockEntryToken,
+                     BlockMappingStartToken, BlockSequenceStartToken,
+                     DirectiveToken, DocumentEndToken, DocumentStartToken,
+                     FlowEntryToken, FlowMappingEndToken,
+                     FlowMappingStartToken, FlowSequenceEndToken,
+                     FlowSequenceStartToken, KeyToken, ScalarToken,
+                     StreamEndToken, StreamStartToken, TagToken, Token,
+                     ValueToken,)
+from .events import (AliasEvent, CollectionEndEvent, CollectionStartEvent,
+                     DocumentEndEvent, DocumentStartEvent, Event,
+                     MappingEndEvent, MappingStartEvent, NodeEvent,
+                     ScalarEvent, SequenceEndEvent, SequenceStartEvent,
+                     StreamEndEvent, StreamStartEvent,)
+from .scanner import (Scanner, ScannerError,)
 
 class ParserError(MarkedYAMLError):
     pass
@@ -482,7 +493,7 @@ class Parser:
                     token = self.peek_token()
                     raise ParserError("while parsing a flow sequence", self.marks[-1],
                             "expected ',' or ']', but got %r" % token.id, token.start_mark)
-            
+
             if self.check_token(KeyToken):
                 token = self.peek_token()
                 event = MappingStartEvent(None, None, True,

--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -2,8 +2,9 @@
 __all__ = ['BaseRepresenter', 'SafeRepresenter', 'Representer',
     'RepresenterError']
 
-from .error import *
-from .nodes import *
+from .error import (Mark, MarkedYAMLError, YAMLError,)
+from .nodes import (CollectionNode, MappingNode, Node, ScalarNode,
+                    SequenceNode,)
 
 import datetime, copyreg, types, base64, collections
 

--- a/lib/yaml/resolver.py
+++ b/lib/yaml/resolver.py
@@ -1,8 +1,9 @@
 
 __all__ = ['BaseResolver', 'Resolver']
 
-from .error import *
-from .nodes import *
+from .error import (Mark, MarkedYAMLError, YAMLError,)
+from .nodes import (CollectionNode, MappingNode, Node, ScalarNode,
+                    SequenceNode,)
 
 import re
 

--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -27,7 +27,14 @@
 __all__ = ['Scanner', 'ScannerError']
 
 from .error import MarkedYAMLError
-from .tokens import *
+from .tokens import (AliasToken, AnchorToken, BlockEndToken, BlockEntryToken,
+                     BlockMappingStartToken, BlockSequenceStartToken,
+                     DirectiveToken, DocumentEndToken, DocumentStartToken,
+                     FlowEntryToken, FlowMappingEndToken,
+                     FlowMappingStartToken, FlowSequenceEndToken,
+                     FlowSequenceStartToken, KeyToken, ScalarToken,
+                     StreamEndToken, StreamStartToken, TagToken, Token,
+                     ValueToken,)
 
 class ScannerError(MarkedYAMLError):
     pass
@@ -313,7 +320,7 @@ class Scanner:
         # Remove the saved possible key position at the current flow level.
         if self.flow_level in self.possible_simple_keys:
             key = self.possible_simple_keys[self.flow_level]
-            
+
             if key.required:
                 raise ScannerError("while scanning a simple key", key.mark,
                         "could not find expected ':'", self.get_mark())
@@ -362,11 +369,11 @@ class Scanner:
 
         # Read the token.
         mark = self.get_mark()
-        
+
         # Add STREAM-START.
         self.tokens.append(StreamStartToken(mark, mark,
             encoding=self.encoding))
-        
+
 
     def fetch_stream_end(self):
 
@@ -380,7 +387,7 @@ class Scanner:
 
         # Read the token.
         mark = self.get_mark()
-        
+
         # Add STREAM-END.
         self.tokens.append(StreamEndToken(mark, mark))
 
@@ -388,7 +395,7 @@ class Scanner:
         self.done = True
 
     def fetch_directive(self):
-        
+
         # Set the current indentation to -1.
         self.unwind_indent(-1)
 
@@ -515,7 +522,7 @@ class Scanner:
         self.tokens.append(BlockEntryToken(start_mark, end_mark))
 
     def fetch_key(self):
-        
+
         # Block context needs additional checks.
         if not self.flow_level:
 
@@ -565,7 +572,7 @@ class Scanner:
 
         # It must be a part of a complex key.
         else:
-            
+
             # Block context needs additional checks.
             # (Do we really need them? They will be caught by the parser
             # anyway.)
@@ -1017,14 +1024,14 @@ class Scanner:
                 # Unfortunately, folding rules are ambiguous.
                 #
                 # This is the folding according to the specification:
-                
+
                 if folded and line_break == '\n'    \
                         and leading_non_space and self.peek() not in ' \t':
                     if not breaks:
                         chunks.append(' ')
                 else:
                     chunks.append(line_break)
-                
+
                 # This is Clark Evans's interpretation (also in the spec
                 # examples):
                 #

--- a/lib/yaml/serializer.py
+++ b/lib/yaml/serializer.py
@@ -2,8 +2,14 @@
 __all__ = ['Serializer', 'SerializerError']
 
 from .error import YAMLError
-from .events import *
-from .nodes import *
+from .events import (AliasEvent, CollectionEndEvent, CollectionStartEvent,
+                     DocumentEndEvent, DocumentStartEvent, Event,
+                     MappingEndEvent, MappingStartEvent, NodeEvent,
+                     ScalarEvent, SequenceEndEvent, SequenceStartEvent,
+                     StreamEndEvent, StreamStartEvent,)
+from .nodes import (CollectionNode, MappingNode, Node, ScalarNode,
+                    SequenceNode,)
+
 
 class SerializerError(YAMLError):
     pass


### PR DESCRIPTION
@ingydotnet  I had originally planned to try a first PR where I added some documentation, but I re-prioritized this first. I find it very difficult to nagivate code that use `import *` because it's not immediately clear what is coming from where, especially if there are more than one of them. However, `import *` is undeniably useful when you are in the midst of writing a repo and you already know what lives where (or in other use cases where you need to mirror another module dynamically).

This is the reason I wrote [mkinit](https://github.com/Erotemic/mkinit), which is a library that helps autogenerate code roughly equivalent to `import *`. I rank the program on this repo and it doesn't seem there is any crazy dynamic logic that would mess up mkinit's static analysis. The code in the `__init__.py` is autogenerated as-is, I defined the `__submodules__` attribute to restrict mkinit to only working with those modules that were already `import *`-ed and I added a `__dev__` note comment that shows a user the commands that were used to do the auto-generation.

For the other files, I used mkinit to help, but it only works on `__init__.py` files at the moment (although, this use case does inspire me to upgrade it such that it can work it's magic to actually replace `import *` in files rather than just generating a specified `__init__.py` file). But what I did was I ran `mkinit` on the entire repo and told it to generate attrs for all the submodules, and then I did a manual copy/paste to overwrite things where appropriate.

Also, unless I missed some magic logic that defined a global `loader` variable in `lib/yaml/__init__.py`, then the functions `add_constructor`, `add_path_resolver`, etc... have a NameError in one of their code paths. If this is real, this does serve as evidence for the value of explicitly stating your imports. It makes it a lot easier for linters like pyflake to catch these errors (or maybe I'm just missing how that global was supposed to be populated).