### PR TITLE
Add python 3.11 support

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,10 @@
+# PyYAML Security Policy
+
+## Reporting a Suspected Vulnerability
+
+The PyYAML project encourages responsible disclosure of suspected security
+vulnerabilities. However, we do not offer bug bounties, paid disclosure, or
+paid fixes for discovered vulnerabilities. To report a suspected security
+vulnerability, please e-mail details to <security@pyyaml.org> without creating
+public issues, pull requests, or discussion. Non-security correspondence to
+this address will be ignored.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,17 +123,20 @@ jobs:
 #        - { platform: manylinux1, arch: x86_64, spec: cp37 }
 #        - { platform: manylinux1, arch: x86_64, spec: cp38 }
 #        - { platform: manylinux1, arch: x86_64, spec: cp39 }
-        - { platform: manylinux2014, arch: x86_64, spec: cp310 }
+#        - { platform: manylinux2014, arch: x86_64, spec: cp310 }
+        - { platform: manylinux2014, arch: x86_64, spec: cp311 }
 #        - { platform: manylinux2014, arch: aarch64, spec: cp36 }
 #        - { platform: manylinux2014, arch: aarch64, spec: cp37 }
 #        - { platform: manylinux2014, arch: aarch64, spec: cp38 }
 #        - { platform: manylinux2014, arch: aarch64, spec: cp39 }
 #        - { platform: manylinux2014, arch: aarch64, spec: cp310 }
+#        - { platform: manylinux2014, arch: aarch64, spec: cp311 }
 #        - { platform: manylinux2014, arch: s390x, spec: cp36 }
 #        - { platform: manylinux2014, arch: s390x, spec: cp37 }
 #        - { platform: manylinux2014, arch: s390x, spec: cp38 }
 #        - { platform: manylinux2014, arch: s390x, spec: cp39 }
 #        - { platform: manylinux2014, arch: s390x, spec: cp310 }
+#        - { platform: manylinux2014, arch: s390x, spec: cp311 }
 
     steps:
     - name: Checkout PyYAML
@@ -233,7 +236,8 @@ jobs:
 #        - spec: cp37-macosx_x86_64
 #        - spec: cp38-macosx_x86_64
 #        - spec: cp39-macosx_x86_64
-        - spec: cp310-macosx_x86_64
+#        - spec: cp310-macosx_x86_64
+        - spec: cp311-macosx_x86_64
 
 #        # build for arm64 under a hacked macOS 12 self-hosted x86_64-on-arm64 runner until arm64 is fully supported
 #        # FIXME: ? cp38-macosx_arm64 requires special handling and fails some test_zdist tests under cibw 2.1.2, skip it (so Apple's XCode python3 won't have a wheel)
@@ -245,6 +249,13 @@ jobs:
 #          sdkroot: macosx11.3
 #
 #        - spec: cp310-macosx_arm64
+#          deployment_target: '11.0'
+#          runs_on: [self-hosted, macOS, arm64]
+#          arch: arm64
+#          run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+#          sdkroot: macosx11.3
+#
+#        - spec: cp311-macosx_arm64
 #          deployment_target: '11.0'
 #          runs_on: [self-hosted, macOS, arm64]
 #          arch: arm64
@@ -351,10 +362,14 @@ jobs:
 #          build_arch: x64
 #          python_arch: x64
 #          spec: 3.9
+#        - platform: windows-2016
+#          build_arch: x64
+#          python_arch: x64
+#          spec: '3.10'
         - platform: windows-2016
           build_arch: x64
           python_arch: x64
-          spec: '3.10'
+          spec: '3.11.0-rc.1'
         - platform: windows-2016
           build_arch: win32
           python_arch: x86
@@ -371,10 +386,14 @@ jobs:
 #          build_arch: win32
 #          python_arch: x86
 #          spec: 3.9
+#        - platform: windows-2016
+#          build_arch: win32
+#          python_arch: x86
+#          spec: '3.10'
         - platform: windows-2016
           build_arch: win32
           python_arch: x86
-          spec: '3.10'
+          spec: '3.11.0-rc.1'
     steps:
     # autocrlf screws up tests under Windows
     - name: Set git to use LF

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,7 +369,7 @@ jobs:
         - platform: windows-2019
           build_arch: x64
           python_arch: x64
-          spec: '3.11.0-rc.1'
+          spec: '3.11.0-rc.2'
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
@@ -393,7 +393,7 @@ jobs:
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
-          spec: '3.11.0-rc.1'
+          spec: '3.11.0-rc.2'
     steps:
     # autocrlf screws up tests under Windows
     - name: Set git to use LF

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,9 +304,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - platform: windows-2016
+        - platform: windows-2019
           arch: x64
-        - platform: windows-2016
+        - platform: windows-2019
           arch: win32
     steps:
     - name: Get cached libyaml state
@@ -334,7 +334,7 @@ jobs:
         mkdir libyaml/build
 
         pushd libyaml/build
-        cmake.exe -G "Visual Studio 15 2017" -A ${{ matrix.arch }} -DYAML_STATIC_LIB_NAME=yaml ..
+        cmake.exe -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -DYAML_STATIC_LIB_NAME=yaml ..
         cmake.exe --build . --config Release
         popd
 
@@ -346,51 +346,51 @@ jobs:
     strategy:
       matrix:
         include:
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: 3.6
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: x64
 #          python_arch: x64
 #          spec: 3.7
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: x64
 #          python_arch: x64
 #          spec: 3.8
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: x64
 #          python_arch: x64
 #          spec: 3.9
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: x64
 #          python_arch: x64
 #          spec: '3.10'
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: '3.11.0-rc.1'
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: 3.6
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: win32
 #          python_arch: x86
 #          spec: 3.7
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: win32
 #          python_arch: x86
 #          spec: 3.8
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: win32
 #          python_arch: x86
 #          spec: 3.9
-#        - platform: windows-2016
+#        - platform: windows-2019
 #          build_arch: win32
 #          python_arch: x86
 #          spec: '3.10'
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: '3.11.0-rc.1'

--- a/.github/workflows/manual_artifact_build.yaml
+++ b/.github/workflows/manual_artifact_build.yaml
@@ -302,9 +302,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - platform: windows-2016
+        - platform: windows-2019
           arch: x64
-        - platform: windows-2016
+        - platform: windows-2019
           arch: win32
     steps:
     - name: Get cached libyaml state
@@ -332,7 +332,7 @@ jobs:
         mkdir libyaml/build
 
         pushd libyaml/build
-        cmake.exe -G "Visual Studio 15 2017" -A ${{ matrix.arch }} -DYAML_STATIC_LIB_NAME=yaml ..
+        cmake.exe -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -DYAML_STATIC_LIB_NAME=yaml ..
         cmake.exe --build . --config Release
         popd
 
@@ -344,51 +344,51 @@ jobs:
     strategy:
       matrix:
         include:
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: 3.6
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: 3.7
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: 3.8
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: 3.9
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: '3.10'
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: x64
           python_arch: x64
           spec: '3.11.0-rc.1'
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: 3.6
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: 3.7
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: 3.8
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: 3.9
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: '3.10'
-        - platform: windows-2016
+        - platform: windows-2019
           build_arch: win32
           python_arch: x86
           spec: '3.11.0-rc.1'

--- a/.github/workflows/manual_artifact_build.yaml
+++ b/.github/workflows/manual_artifact_build.yaml
@@ -122,16 +122,19 @@ jobs:
         - { platform: manylinux1, arch: x86_64, spec: cp38 }
         - { platform: manylinux1, arch: x86_64, spec: cp39 }
         - { platform: manylinux2014, arch: x86_64, spec: cp310 }
+        - { platform: manylinux2014, arch: x86_64, spec: cp311 }
         - { platform: manylinux2014, arch: aarch64, spec: cp36 }
         - { platform: manylinux2014, arch: aarch64, spec: cp37 }
         - { platform: manylinux2014, arch: aarch64, spec: cp38 }
         - { platform: manylinux2014, arch: aarch64, spec: cp39 }
         - { platform: manylinux2014, arch: aarch64, spec: cp310 }
+        - { platform: manylinux2014, arch: aarch64, spec: cp311 }
         - { platform: manylinux2014, arch: s390x, spec: cp36 }
         - { platform: manylinux2014, arch: s390x, spec: cp37 }
         - { platform: manylinux2014, arch: s390x, spec: cp38 }
         - { platform: manylinux2014, arch: s390x, spec: cp39 }
         - { platform: manylinux2014, arch: s390x, spec: cp310 }
+        - { platform: manylinux2014, arch: s390x, spec: cp311 }
 
     steps:
     - name: Checkout PyYAML
@@ -232,6 +235,7 @@ jobs:
         - spec: cp38-macosx_x86_64
         - spec: cp39-macosx_x86_64
         - spec: cp310-macosx_x86_64
+        - spec: cp311-macosx_x86_64
 
         # build for arm64 under a hacked macOS 12 self-hosted x86_64-on-arm64 runner until arm64 is fully supported
         # FIXME: ? cp38-macosx_arm64 requires special handling and fails some test_zdist tests under cibw 2.1.2, skip it (so Apple's XCode python3 won't have a wheel)
@@ -243,6 +247,13 @@ jobs:
           sdkroot: macosx11.3
 
         - spec: cp310-macosx_arm64
+          deployment_target: '11.0'
+          runs_on: [self-hosted, macOS, arm64]
+          arch: arm64
+          run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+          sdkroot: macosx11.3
+
+        - spec: cp311-macosx_arm64
           deployment_target: '11.0'
           runs_on: [self-hosted, macOS, arm64]
           arch: arm64
@@ -354,6 +365,10 @@ jobs:
           python_arch: x64
           spec: '3.10'
         - platform: windows-2016
+          build_arch: x64
+          python_arch: x64
+          spec: '3.11.0-rc.1'
+        - platform: windows-2016
           build_arch: win32
           python_arch: x86
           spec: 3.6
@@ -373,6 +388,10 @@ jobs:
           build_arch: win32
           python_arch: x86
           spec: '3.10'
+        - platform: windows-2016
+          build_arch: win32
+          python_arch: x86
+          spec: '3.11.0-rc.1'
     steps:
     # autocrlf screws up tests under Windows
     - name: Set git to use LF

--- a/.github/workflows/manual_artifact_build.yaml
+++ b/.github/workflows/manual_artifact_build.yaml
@@ -367,7 +367,7 @@ jobs:
         - platform: windows-2019
           build_arch: x64
           python_arch: x64
-          spec: '3.11.0-rc.1'
+          spec: '3.11.0-rc.2'
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
@@ -391,7 +391,7 @@ jobs:
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
-          spec: '3.11.0-rc.1'
+          spec: '3.11.0-rc.2'
     steps:
     # autocrlf screws up tests under Windows
     - name: Set git to use LF

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3,py36,py37,py38,py39,py310
+envlist = pypy3,py36,py37,py38,py39,py310,py311
 
 [testenv]
 deps =


### PR DESCRIPTION
Now that python 3.11.0rc1 is available (ABI stable), wheels for python 3.11 can be built.
 
closes #630