### PR TITLE
Support musllinux wheels build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,8 @@ jobs:
         - { platform: manylinux2014, arch: x86_64 }
 #        - { platform: manylinux2014, arch: aarch64 }
 #        - { platform: manylinux2014, arch: s390x }
+#        - { platform: musllinux_1_1, arch: x86_64 }
+#        - { platform: musllinux_1_1, arch: aarch64 }
     env:
       DOCKER_IMAGE: quay.io/pypa/${{matrix.cfg.platform}}_${{matrix.cfg.arch}}
     steps:
@@ -103,7 +105,7 @@ jobs:
         --env LIBYAML_REPO
         --workdir /io
         "$DOCKER_IMAGE"
-        /io/packaging/build/libyaml.sh
+        sh -c "${{startsWith(matrix.cfg.platform, 'musllinux') && 'apk add perl-utils && ' || ''}}/io/packaging/build/libyaml.sh"
       if: steps.cached_libyaml.outputs.cache-hit != 'true'
 
     - name: ensure output is world readable (or cache fill fails with Permission Denied)
@@ -137,6 +139,18 @@ jobs:
 #        - { platform: manylinux2014, arch: s390x, spec: cp39 }
 #        - { platform: manylinux2014, arch: s390x, spec: cp310 }
 #        - { platform: manylinux2014, arch: s390x, spec: cp311 }
+#        - { platform: musllinux_1_1, arch: x86_64, spec: cp36 }
+#        - { platform: musllinux_1_1, arch: x86_64, spec: cp37 }
+#        - { platform: musllinux_1_1, arch: x86_64, spec: cp38 }
+#        - { platform: musllinux_1_1, arch: x86_64, spec: cp39 }
+#        - { platform: musllinux_1_1, arch: x86_64, spec: cp310 }
+#        - { platform: musllinux_1_1, arch: x86_64, spec: cp311 }
+#        - { platform: musllinux_1_1, arch: aarch64, spec: cp36 }
+#        - { platform: musllinux_1_1, arch: aarch64, spec: cp37 }
+#        - { platform: musllinux_1_1, arch: aarch64, spec: cp38 }
+#        - { platform: musllinux_1_1, arch: aarch64, spec: cp39 }
+#        - { platform: musllinux_1_1, arch: aarch64, spec: cp310 }
+#        - { platform: musllinux_1_1, arch: aarch64, spec: cp311 }
 
     steps:
     - name: Checkout PyYAML
@@ -160,7 +174,7 @@ jobs:
     - name: Build/Test/Package
       env:
         CIBW_ARCHS: all
-        CIBW_BUILD: ${{matrix.spec}}-manylinux_${{matrix.arch}}
+        CIBW_BUILD: ${{matrix.spec}}-${{startsWith(matrix.platform, 'musllinux') && 'musllinux' || 'manylinux'}}_${{matrix.arch}}
         CIBW_BUILD_VERBOSITY: 1
         # containerized Linux builds require explicit CIBW_ENVIRONMENT
         CIBW_ENVIRONMENT: >

--- a/.github/workflows/manual_artifact_build.yaml
+++ b/.github/workflows/manual_artifact_build.yaml
@@ -75,6 +75,8 @@ jobs:
         - { platform: manylinux2014, arch: x86_64 }
         - { platform: manylinux2014, arch: aarch64 }
         - { platform: manylinux2014, arch: s390x }
+        - { platform: musllinux_1_1, arch: x86_64 }
+        - { platform: musllinux_1_1, arch: aarch64 }
     env:
       DOCKER_IMAGE: quay.io/pypa/${{matrix.cfg.platform}}_${{matrix.cfg.arch}}
     steps:
@@ -101,7 +103,7 @@ jobs:
         --env LIBYAML_REPO
         --workdir /io
         "$DOCKER_IMAGE"
-        /io/packaging/build/libyaml.sh
+        sh -c "${{startsWith(matrix.cfg.platform, 'musllinux') && 'apk add perl-utils && ' || ''}}/io/packaging/build/libyaml.sh"
       if: steps.cached_libyaml.outputs.cache-hit != 'true'
 
     - name: ensure output is world readable (or cache fill fails with Permission Denied)
@@ -135,6 +137,18 @@ jobs:
         - { platform: manylinux2014, arch: s390x, spec: cp39 }
         - { platform: manylinux2014, arch: s390x, spec: cp310 }
         - { platform: manylinux2014, arch: s390x, spec: cp311 }
+        - { platform: musllinux_1_1, arch: x86_64, spec: cp36 }
+        - { platform: musllinux_1_1, arch: x86_64, spec: cp37 }
+        - { platform: musllinux_1_1, arch: x86_64, spec: cp38 }
+        - { platform: musllinux_1_1, arch: x86_64, spec: cp39 }
+        - { platform: musllinux_1_1, arch: x86_64, spec: cp310 }
+        - { platform: musllinux_1_1, arch: x86_64, spec: cp311 }
+        - { platform: musllinux_1_1, arch: aarch64, spec: cp36 }
+        - { platform: musllinux_1_1, arch: aarch64, spec: cp37 }
+        - { platform: musllinux_1_1, arch: aarch64, spec: cp38 }
+        - { platform: musllinux_1_1, arch: aarch64, spec: cp39 }
+        - { platform: musllinux_1_1, arch: aarch64, spec: cp310 }
+        - { platform: musllinux_1_1, arch: aarch64, spec: cp311 }
 
     steps:
     - name: Checkout PyYAML
@@ -158,7 +172,7 @@ jobs:
     - name: Build/Test/Package
       env:
         CIBW_ARCHS: all
-        CIBW_BUILD: ${{matrix.spec}}-manylinux_${{matrix.arch}}
+        CIBW_BUILD: ${{matrix.spec}}-${{startsWith(matrix.platform, 'musllinux') && 'musllinux' || 'manylinux'}}_${{matrix.arch}}
         CIBW_BUILD_VERBOSITY: 1
         # containerized Linux builds require explicit CIBW_ENVIRONMENT
         CIBW_ENVIRONMENT: >


### PR DESCRIPTION
Hey :)

Over the past year almost every major package added `musllinux` wheels to its releases.
Using an Alpine Python image for your containers is a bit problematic when build tools installation is needed for your packages, making the image much bigger than desired...

I noticed `pyyaml` is one of the few packages I'm still getting as `tar.gz`, so thought I'd open a PR for it.
Seemed to me that for musllinux having `x86_64` and `aarch64` as a start should be just fine.

Would be cool to upload those wheels to PyPI like the newly-added Python 3.11 wheels, without waiting for a new release that could take a while.

A successful build output can be seen here, I dropped build cache before running to make sure `libyaml` build didn't break:
https://github.com/ben9923/pyyaml/actions/runs/3167170483

Resolves #606 

#### Two things I noticed that are _not_ addressed here:
- Shipping pure Python wheels would also be cool to make installation a bit faster where (compiled) wheels are not available.
- It seems like `platform` matrix option is not fully respected when building Linux wheels, probably due to `CIBW_MANYLINUX_*_IMAGE` not being set accordingly (It's only used when building `libyaml`).
  Currently it means `{cp36-cp39}-manylinux1` wheels are replaced by (default) `manylinux2014` wheels on CI invocation.