### PR TITLE
Use `ChainMap` to improve representer/constructor inheritance

### DIFF
--- a/lib/yaml/_utils.py
+++ b/lib/yaml/_utils.py
@@ -1,0 +1,42 @@
+import collections
+
+
+class InheritMapMixin:
+    """Adds :py:class:`collections.ChainMap` class attributes based on MRO.
+
+    The added class attributes provide each subclass with its own mapping that
+    works just like method resolution: each ancestor type in ``__mro__`` is
+    visited until an entry is found in the ancestor-owned map.
+
+    For example, for an inheritance DAG of ``InheritMapMixin`` <- ``Foo`` <-
+    ``Bar`` <- ``Baz`` and a desired attribute name of ``"_m"``:
+
+    1. ``Foo._m`` is set to ``ChainMap({})``.
+    2. ``Bar._m`` is set to ``ChainMap({}, Foo._m.maps[0])``.
+    3. ``Baz._m`` is set to ``ChainMap({}, Bar._m.maps[0], Foo._m.maps[0])``.
+    """
+
+    @classmethod
+    def __init_subclass__(cls, *, inherit_map_attrs=None, **kwargs):
+        """Adds :py:class:`collections.ChainMap` class attributes based on MRO.
+
+        :param inherit_map_attrs:
+            Optional iterable of names of class attributes that will be set to a
+            :py:class:`collections.ChainMap` containing the MRO-based list of
+            ancestor maps.
+        """
+        super().__init_subclass__(**kwargs)
+        attrs = getattr(cls, "_inherit_map_attrs", set())
+        if inherit_map_attrs:
+            attrs = {*attrs, *inherit_map_attrs}
+            cls._inherit_map_attrs = attrs
+        for attr in attrs:
+            maps = [{}]  # maps[0] is for cls itself.
+            for c in cls.__mro__[1:]:  # cls.__mro__[0] is cls itself.
+                if (
+                        issubclass(c, InheritMapMixin) and
+                        c is not InheritMapMixin and
+                        attr in getattr(c, "_inherit_map_attrs", set())
+                ):
+                    maps.append(getattr(c, attr).maps[0])
+            setattr(cls, attr, collections.ChainMap(*maps))

--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -13,14 +13,15 @@ from .nodes import *
 
 import collections.abc, datetime, base64, binascii, re, sys, types
 
+from . import _utils
+
+
 class ConstructorError(MarkedYAMLError):
     pass
 
-class BaseConstructor:
-
-    yaml_constructors = {}
-    yaml_multi_constructors = {}
-
+class BaseConstructor(
+        _utils.InheritMapMixin,
+        inherit_map_attrs={"yaml_constructors", "yaml_multi_constructors"}):
     def __init__(self):
         self.constructed_objects = {}
         self.recursive_objects = {}
@@ -158,14 +159,10 @@ class BaseConstructor:
 
     @classmethod
     def add_constructor(cls, tag, constructor):
-        if not 'yaml_constructors' in cls.__dict__:
-            cls.yaml_constructors = cls.yaml_constructors.copy()
         cls.yaml_constructors[tag] = constructor
 
     @classmethod
     def add_multi_constructor(cls, tag_prefix, multi_constructor):
-        if not 'yaml_multi_constructors' in cls.__dict__:
-            cls.yaml_multi_constructors = cls.yaml_multi_constructors.copy()
         cls.yaml_multi_constructors[tag_prefix] = multi_constructor
 
 class SafeConstructor(BaseConstructor):

--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -7,14 +7,15 @@ from .nodes import *
 
 import datetime, copyreg, types, base64, collections
 
+from . import _utils
+
+
 class RepresenterError(YAMLError):
     pass
 
-class BaseRepresenter:
-
-    yaml_representers = {}
-    yaml_multi_representers = {}
-
+class BaseRepresenter(
+        _utils.InheritMapMixin,
+        inherit_map_attrs={"yaml_representers", "yaml_multi_representers"}):
     def __init__(self, default_style=None, default_flow_style=False, sort_keys=True):
         self.default_style = default_style
         self.sort_keys = sort_keys
@@ -64,14 +65,10 @@ class BaseRepresenter:
 
     @classmethod
     def add_representer(cls, data_type, representer):
-        if not 'yaml_representers' in cls.__dict__:
-            cls.yaml_representers = cls.yaml_representers.copy()
         cls.yaml_representers[data_type] = representer
 
     @classmethod
     def add_multi_representer(cls, data_type, representer):
-        if not 'yaml_multi_representers' in cls.__dict__:
-            cls.yaml_multi_representers = cls.yaml_multi_representers.copy()
         cls.yaml_multi_representers[data_type] = representer
 
     def represent_scalar(self, tag, value, style=None):

--- a/tests/lib/test_representer.py
+++ b/tests/lib/test_representer.py
@@ -38,6 +38,78 @@ def test_representer_types(code_filename, verbose=False):
 
 test_representer_types.unittest = ['.code']
 
+def test_representer_inheritance(verbose=False):
+    class Widget:
+        pass
+
+    class Gizmo:
+        pass
+
+    def represent_widget(representer, obj):
+        return representer.represent_scalar("!widget", "widget")
+
+    def represent_gizmo1(representer, obj):
+        return representer.represent_scalar("!gizmo", "gizmo1")
+
+    def represent_gizmo2(representer, obj):
+        return representer.represent_scalar("!gizmo", "gizmo2")
+
+    def represent_gizmo3(representer, obj):
+        return representer.represent_scalar("!gizmo", "gizmo3")
+
+    class DumperParent(yaml.Dumper):
+        pass
+
+    class DumperChild(DumperParent):
+        pass
+
+    # Add a representer to the child.  Note that no representer has been added
+    # to the parent yet.
+    DumperChild.add_representer(Widget, represent_widget)
+    if verbose:
+        print("After adding a representer to the child Dumper:")
+        print(f"  {DumperParent.yaml_representers=}")
+        print(f"  {DumperChild.yaml_representers=}")
+    assert DumperChild.yaml_representers[Widget] is represent_widget
+    assert Widget not in DumperParent.yaml_representers
+
+    # A representer is now added to the parent.  The child should be able to see
+    # this new representer even though it was added after a representer was
+    # added to the child above.
+    DumperParent.add_representer(Gizmo, represent_gizmo1)
+    if verbose:
+        print("After adding a representer to the parent Dumper:")
+        print(f"  {DumperParent.yaml_representers=}")
+        print(f"  {DumperChild.yaml_representers=}")
+    assert DumperChild.yaml_representers[Widget] is represent_widget
+    assert Widget not in DumperParent.yaml_representers
+    assert DumperParent.yaml_representers[Gizmo] is represent_gizmo1
+    assert DumperChild.yaml_representers[Gizmo] is represent_gizmo1
+
+    # Override a parent representer in the child.
+    DumperChild.add_representer(Gizmo, represent_gizmo2)
+    if verbose:
+        print("After overriding a parent's representer:")
+        print(f"  {DumperParent.yaml_representers=}")
+        print(f"  {DumperChild.yaml_representers=}")
+    assert DumperChild.yaml_representers[Widget] is represent_widget
+    assert Widget not in DumperParent.yaml_representers
+    assert DumperParent.yaml_representers[Gizmo] is represent_gizmo1
+    assert DumperChild.yaml_representers[Gizmo] is represent_gizmo2
+
+    # Changing the parent's overridden representer should not affect the child.
+    DumperParent.add_representer(Gizmo, represent_gizmo3)
+    if verbose:
+        print("After changing the parent's overridden representer:")
+        print(f"  {DumperParent.yaml_representers=}")
+        print(f"  {DumperChild.yaml_representers=}")
+    assert DumperChild.yaml_representers[Widget] is represent_widget
+    assert Widget not in DumperParent.yaml_representers
+    assert DumperParent.yaml_representers[Gizmo] is represent_gizmo3
+    assert DumperChild.yaml_representers[Gizmo] is represent_gizmo2
+
+test_representer_inheritance.unittest = True
+
 if __name__ == '__main__':
     import test_appliance
     test_appliance.run(globals())


### PR DESCRIPTION
Before this change, a child Dumper "inherited" its parent Dumper's representers by simply copying the parent's representers the first time a new representer was registered with the child Dumper.  This approach works as users expect only if representers are never added to a parent (ancestor) Dumper after representers are added to a child (descendant) Dumper.  Same goes for Loaders and their registered constructors.

This commit uses a `collections.ChainMap` built from ancestor `dict` objects in method resolution order (MRO) to provide true inheritance of representers (for Dumpers) and constructors (for Loaders).

This is technically a backwards-incompatible change: This change breaks any code that intentionally subverts the expected inheritance behavior by registering a function in an ancestor class *after* registering a function in a descendant class.