### PR TITLE
Pin Cython build constraint to < 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,7 +197,7 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
-    runs-on: ${{ matrix.runs_on || 'macos-10.15' }}
+    runs-on: ${{ matrix.runs_on || 'macos-11' }}
     steps:
     - name: Check cached libyaml state
       id: cached_libyaml
@@ -225,7 +225,7 @@ jobs:
   macos_pyyaml:
     needs: macos_libyaml
     name: pyyaml ${{ matrix.spec }}
-    runs-on: ${{ matrix.runs_on || 'macos-10.15' }}
+    runs-on: ${{ matrix.runs_on || 'macos-11' }}
     defaults:
       run:
         shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
@@ -233,6 +233,7 @@ jobs:
       matrix:
         include:
         - spec: cp36-macosx_x86_64
+          cibw_version: cibuildwheel==2.11.1
 #        - spec: cp37-macosx_x86_64
 #        - spec: cp38-macosx_x86_64
 #        - spec: cp39-macosx_x86_64
@@ -288,7 +289,7 @@ jobs:
         SDKROOT: ${{ matrix.sdkroot || 'macosx' }}
       run: |
         python3 -V
-        python3 -m pip install -U --user cibuildwheel
+        python3 -m pip install -U --user ${{ matrix.cibw_version || 'cibuildwheel' }}
         python3 -m cibuildwheel --platform auto --output-dir dist .
 
     - name: Upload artifacts
@@ -369,7 +370,7 @@ jobs:
         - platform: windows-2019
           build_arch: x64
           python_arch: x64
-          spec: '3.11.0-rc.2'
+          spec: '3.11'
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
@@ -393,7 +394,7 @@ jobs:
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
-          spec: '3.11.0-rc.2'
+          spec: '3.11'
     steps:
     # autocrlf screws up tests under Windows
     - name: Set git to use LF
@@ -429,7 +430,7 @@ jobs:
       run: |
         set -eux
         python -V
-        python -m pip install Cython wheel
+        python -m pip install "Cython<3.0" wheel
 
         python setup.py \
         --with-libyaml build_ext \

--- a/.github/workflows/manual_artifact_build.yaml
+++ b/.github/workflows/manual_artifact_build.yaml
@@ -195,7 +195,7 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
-    runs-on: ${{ matrix.runs_on || 'macos-10.15' }}
+    runs-on: ${{ matrix.runs_on || 'macos-11' }}
     steps:
     - name: Check cached libyaml state
       id: cached_libyaml
@@ -223,7 +223,7 @@ jobs:
   macos_pyyaml:
     needs: macos_libyaml
     name: pyyaml ${{ matrix.spec }}
-    runs-on: ${{ matrix.runs_on || 'macos-10.15' }}
+    runs-on: ${{ matrix.runs_on || 'macos-11' }}
     defaults:
       run:
         shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
@@ -231,8 +231,11 @@ jobs:
       matrix:
         include:
         - spec: cp36-macosx_x86_64
+          cibw_version: cibuildwheel==2.11.1
         - spec: cp37-macosx_x86_64
+          cibw_version: cibuildwheel==2.11.1
         - spec: cp38-macosx_x86_64
+          cibw_version: cibuildwheel==2.11.1
         - spec: cp39-macosx_x86_64
         - spec: cp310-macosx_x86_64
         - spec: cp311-macosx_x86_64
@@ -286,7 +289,7 @@ jobs:
         SDKROOT: ${{ matrix.sdkroot || 'macosx' }}
       run: |
         python3 -V
-        python3 -m pip install -U --user cibuildwheel
+        python3 -m pip install -U --user ${{ matrix.cibw_version || 'cibuildwheel' }}
         python3 -m cibuildwheel --platform auto --output-dir dist .
 
     - name: Upload artifacts
@@ -367,7 +370,7 @@ jobs:
         - platform: windows-2019
           build_arch: x64
           python_arch: x64
-          spec: '3.11.0-rc.2'
+          spec: '3.11'
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
@@ -391,7 +394,7 @@ jobs:
         - platform: windows-2019
           build_arch: win32
           python_arch: x86
-          spec: '3.11.0-rc.2'
+          spec: '3.11'
     steps:
     # autocrlf screws up tests under Windows
     - name: Set git to use LF
@@ -427,7 +430,7 @@ jobs:
       run: |
         set -eux
         python -V
-        python -m pip install Cython wheel
+        python -m pip install "Cython<3.0" wheel
 
         python setup.py \
         --with-libyaml build_ext \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython<3.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Temporary workaround for #601.

This is just a stopgap measure to ensure the libyaml extension build continues to function whenever Cython 3.0 is released (date TBD). We'll want to prioritize the extension build rewrite to ensure that PyYAML can support Python > 3.11, as I'd be amazed if they backport things to the Cython 0.x branch once 3.0 has released.

We should discuss if we want to just release this as `6.0.post1` or what, since there are no code changes to the actual library, just build/packaging metadata...