### PR TITLE
Pin Cython build constraint to < 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython<3.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Workaround for issue #601 to keep libyaml extension build functional now that Cython>=3.0 has been released.

Related Issue: #702