### PR TITLE
Fix assert in test for yaml.load

### DIFF
--- a/tests/lib/test_dump_load.py
+++ b/tests/lib/test_dump_load.py
@@ -9,7 +9,7 @@ def test_load_no_loader(verbose=False):
         yaml.load("- foo\n")
     except TypeError:
         return True
-    assert(False, "load() require Loader=...")
+    assert False, "load() require Loader=..."
 test_load_no_loader.unittest = True
 
 def test_load_safeloader(verbose=False):


### PR DESCRIPTION
Fixes assert in `test_load_no_loader` function - the way it's written now, it's always true.