### PR TITLE
fix indent

### DIFF
--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -55,7 +55,7 @@ class Emitter:
 
         # The current indentation level and the stack of previous indents.
         self.indents = []
-        self.indent = None
+        self.indent = indent
 
         # Flow level.
         self.flow_level = 0


### PR DESCRIPTION
At moment setting indent has no value, cause in Emitter class the value is hardcoded to None.