### PR TITLE
[WIP] nested class support

### DIFF
--- a/tests/legacy_tests/data/construct-python-object.code
+++ b/tests/legacy_tests/data/construct-python-object.code
@@ -2,6 +2,8 @@
 AnObject(1, 'two', [3,3,3]),
 AnInstance(1, 'two', [3,3,3]),
 
+NestedOuterObject.NestedInnerObject1.NestedInnerObject2.NestedInnerObject3('hi mom'),
+
 AnObject(1, 'two', [3,3,3]),
 AnInstance(1, 'two', [3,3,3]),
 

--- a/tests/legacy_tests/data/construct-python-object.data
+++ b/tests/legacy_tests/data/construct-python-object.data
@@ -1,5 +1,6 @@
 - !!python/object:test_constructor.AnObject { foo: 1, bar: two, baz: [3,3,3] }
 - !!python/object:test_constructor.AnInstance { foo: 1, bar: two, baz: [3,3,3] }
+- !!python/object:test_constructor@NestedOuterObject.NestedInnerObject1.NestedInnerObject2.NestedInnerObject3 { data: hi mom }
 
 - !!python/object/new:test_constructor.AnObject { args: [1, two], kwds: {baz: [3,3,3]} }
 - !!python/object/apply:test_constructor.AnInstance { args: [1, two], kwds: {baz: [3,3,3]} }

--- a/tests/legacy_tests/test_constructor.py
+++ b/tests/legacy_tests/test_constructor.py
@@ -15,7 +15,7 @@ def execute(code):
 
 def _make_objects():
     global MyLoader, MyDumper, MyTestClass1, MyTestClass2, MyTestClass3, YAMLObject1, YAMLObject2,  \
-            AnObject, AnInstance, AState, ACustomState, InitArgs, InitArgsWithState,    \
+            AnObject, AnInstance, NestedOuterObject, AState, ACustomState, InitArgs, InitArgsWithState,    \
             NewArgs, NewArgsWithState, Reduce, ReduceWithState, Slots, MyInt, MyList, MyDict,  \
             FixedOffset, today, execute, MyFullLoader
 
@@ -127,6 +127,16 @@ def _make_objects():
         def __eq__(self, other):
             return type(self) is type(other) and    \
                     (self.foo, self.bar, self.baz) == (other.foo, other.bar, other.baz)
+
+    class NestedOuterObject:
+        class NestedInnerObject1:
+            class NestedInnerObject2:
+                class NestedInnerObject3:
+                    def __init__(self, data):
+                        self.data = data
+                    def __eq__(self, other):
+                        return type(self) is type(other) and self.data == other.data
+
 
     class AnInstance:
         def __init__(self, foo=None, bar=None, baz=None):


### PR DESCRIPTION
fixes #131 

Could be done with existing "all dots" tag syntax instead of the `@` separator, but discarding the explicit distinction between the module/package and type name makes the import/construction logic a lot less precise when dealing with nested types.
