### PR TITLE
Declare Python 3.12 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Hello,

Since there are already [wheels](https://pypi.org/project/PyYAML/6.0.1/#files) for Python 3.12 on PyPI and [tests](https://github.com/yaml/pyyaml/actions/runs/6866536928/job/18673004978#step:5:462) on CI,
I believe it's worth adding Python 3.12 to the `classifiers`.

Thanks!