### PR TITLE
Add supported interpreters to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py3{13,12,11,10,9,8},pypy3{10,9,8}
+skip_missing_interpreters = true
 
 [testenv]
 deps =
     pytest
 commands =
-    pytest
-
+    pytest {posargs}


### PR DESCRIPTION
_Hello,_

**PyYAML** [declares support](https://github.com/yaml/pyyaml/blob/main/setup.py#L31-L38) for a wide range of Python versions, but not all of them were included in the `envlist` at `tox.ini`, so I'd like to propose changes that:
  * add supported interpreters to `tox.ini`
  * enable the [skip_missing_interpreters](https://tox.wiki/en/stable/config.html#skip_missing_interpreters) option
  * add [{posargs}](https://tox.wiki/en/stable/config.html#substitutions-for-positional-arguments-in-commands) to the test command in order to provide flexibility, so you can pass arguments to `pytest`, e.g.: `tox -- -k test_dump`

With these changes, `tox`'s outcome on my system looks like this:
```
  py313: OK (30.51=setup[21.49]+cmd[9.02] seconds)
  py312: OK (21.70=setup[11.32]+cmd[10.38] seconds)
  py311: OK (21.23=setup[11.13]+cmd[10.10] seconds)
  py310: OK (31.03=setup[17.04]+cmd[13.99] seconds)
  py39: OK (26.91=setup[13.03]+cmd[13.88] seconds)
  py38: OK (28.26=setup[12.68]+cmd[15.58] seconds)
  pypy310: OK (48.78=setup[24.57]+cmd[24.22] seconds)
  pypy39: OK (44.77=setup[18.24]+cmd[26.52] seconds)
  pypy38: SKIP (0.34 seconds)
  congratulations :) (253.70 seconds)
```

_Best regards!_