### PR TITLE
Keep support for python 3.6 and 3.7

### DIFF
--- a/packaging/_pyyaml_pep517.py
+++ b/packaging/_pyyaml_pep517.py
@@ -33,7 +33,7 @@ class ActiveConfigSettings:
 
 
 def _expose_config_settings(real_method, *args, **kwargs):
-    from contextlib import nullcontext
+    from contextlib import ExitStack
     import inspect
 
     sig = inspect.signature(real_method)
@@ -41,9 +41,9 @@ def _expose_config_settings(real_method, *args, **kwargs):
 
     config = boundargs.arguments.get('config_settings')
 
-    ctx = ActiveConfigSettings(config) if config else nullcontext()
-
-    with ctx:
+    with ExitStack() as stack:
+        if config:
+            stack.enter_context(ActiveConfigSettings(config))
         return real_method(*args, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,7 @@ class build_ext(_build_ext):
             if with_ext is not None and not with_ext:
                 continue
             if with_cython:
-                print(f"BUILDING CYTHON EXT; {self.include_dirs=} {self.library_dirs=} {self.define=}")
+                print(f"BUILDING CYTHON EXT; include_dirs={self.include_dirs} library_dirs={self.library_dirs} define={self.define}")
                 ext.sources = self.cython_sources(ext.sources, ext)
             try:
                 self.build_extension(ext)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py36,py37,py38,py39,py310,py311,py312
 
 [testenv]
 deps =


### PR DESCRIPTION
Related to #810 

Breaking changes were introduced here: https://github.com/yaml/pyyaml/pull/808

Overview of build issues: https://github.com/yaml/pyyaml/issues/810#issuecomment-2161650291

I'm not sure how to build locally (`make build` fails because `pyyaml_build_config` is only added in CI?) so I didn't test this PR.

Alternatively to this PR: nuke 6.0.2rc1 on pypi and drop support for python 3.6 and 3.7