### PR TITLE
fix(resolver): reference strings of int as object

### DIFF
--- a/lib/yaml/resolver.py
+++ b/lib/yaml/resolver.py
@@ -218,6 +218,11 @@ Resolver.add_implicit_resolver(
         re.compile(r'^(?:=)$'),
         ['='])
 
+Resolver.add_implicit_resolver(
+        'tag:yaml.org,2002:object',
+        re.compile(r'\d{2,}'),
+        ['0'])
+
 # The following resolver is only for documentation purposes. It cannot work
 # because plain scalars cannot start with '!', '&', or '*'.
 Resolver.add_implicit_resolver(


### PR DESCRIPTION
For strings of numbers (with length 2 or more)
that should maintain leading zeroes, add an
implicit resolver to preserve the object and
return as string.

Examples:
0138 = '0138'
0149 = '0149'

Whereas 0145 doesn't have the issue.

Test mapping:
{
    "test_strs": [
        {"test_str": "0138000000000"},
        {"test_str": "0149000000000"},
        {"test_str": "0145000000000"},
        {"test_str": "5945000000000"},
    ]
}