### PR TITLE
fix: don't import deprecated "wheel" (just to do nothing with it)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools",  # FIXME: declare min/max setuptools versions?
-    "wheel",
     "Cython; python_version < '3.13'",
     "Cython>=3.0; python_version >= '3.13'"
 ]

--- a/setup.py
+++ b/setup.py
@@ -93,11 +93,6 @@ except ImportError:
     if with_cython:
         raise
 
-try:
-    from wheel.bdist_wheel import bdist_wheel
-except ImportError:
-    bdist_wheel = None
-
 
 try:
     from _pyyaml_pep517 import ActiveConfigSettings
@@ -325,8 +320,6 @@ cmdclass = {
     'build_ext': build_ext,
     'test': test,
 }
-if bdist_wheel:
-    cmdclass['bdist_wheel'] = bdist_wheel
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `wheel` package is no longer a dependency of setuptools, so trying to import from it might wipe out the integrated setuptools bdist_wheel command, and will start proceeding a warning or error soon. Since nothing at all is done to it (anymore?), just drop it.