### PR TITLE
make style=... consistent for unquoted scalar tokens

### DIFF
--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -1306,7 +1306,7 @@ class Scanner:
             if not spaces or self.peek() == '#' \
                     or (not self.flow_level and self.column < indent):
                 break
-        return ScalarToken(''.join(chunks), True, start_mark, end_mark)
+        return ScalarToken(''.join(chunks), True, start_mark, end_mark, style='')
 
     def scan_plain_spaces(self, indent, start_mark):
         # See the specification for details.

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,18 @@
+import pytest
+
+import yaml
+from yaml.tokens import StreamStartToken, ScalarToken, StreamEndToken
+
+
+_loaders = (yaml.SafeLoader,)
+if yaml.__with_libyaml__:
+    _loaders += (yaml.CSafeLoader,)
+
+
+@pytest.mark.parametrize('loader_cls', _loaders)
+def test_scan_produces_empty_string_style_for_scalar_node(loader_cls):
+    start, scalar, end = yaml.scan('example', Loader=loader_cls)
+    assert isinstance(start, StreamStartToken)
+    assert isinstance(scalar, ScalarToken)
+    assert scalar.style == ''
+    assert isinstance(end, StreamEndToken)


### PR DESCRIPTION
I chose to match the behaviour of the C scanner (since that is likely the most common scenario given wheels on pypi)

noticed this while using these for pre-commit: https://github.com/pre-commit/pre-commit/pull/3324