### PR TITLE
feat: Add value representer to `enum.StrEnum` type

### DIFF
--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -5,7 +5,7 @@ __all__ = ['BaseRepresenter', 'SafeRepresenter', 'Representer',
 from .error import *
 from .nodes import *
 
-import datetime, copyreg, types, base64, collections
+import datetime, copyreg, types, base64, collections, sys
 
 class RepresenterError(YAMLError):
     pass
@@ -234,6 +234,12 @@ SafeRepresenter.add_representer(type(None),
         SafeRepresenter.represent_none)
 
 SafeRepresenter.add_representer(str,
+        SafeRepresenter.represent_str)
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+
+    SafeRepresenter.add_multi_representer(StrEnum,
         SafeRepresenter.represent_str)
 
 SafeRepresenter.add_representer(bytes,

--- a/tests/test_dump_load.py
+++ b/tests/test_dump_load.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import yaml
 
@@ -13,3 +15,15 @@ def test_load_no_loader():
 
 def test_load_safeloader():
     assert yaml.load("- foo\n", Loader=yaml.SafeLoader)
+
+
+def test_dump_str_enum():
+    if sys.version_info < (3, 11):
+        return
+
+    from enum import StrEnum
+
+    class ContentType(StrEnum):
+        YAML = "YAML"
+
+    assert yaml.load(yaml.dump(ContentType.YAML, Dumper=yaml.SafeDumper), Loader=yaml.SafeLoader) == ContentType.YAML


### PR DESCRIPTION
Hello pyyaml team!

This pull request resolves #722 by add `represent_str()` representer to `enum.StrEnum` type, targeting to python>=3.11.

Though this line can be refactored as:
https://github.com/yaml/pyyaml/blob/69c141adcf805c5ebdc9ba519927642ee5c7f639/lib/yaml/representer.py#L47
```python
for representer in self.yaml_representers:
    if isinstance(data_types[0], representer):
        ...
```

Thanks for the review in advance!

Refs
- https://docs.python.org/3/library/enum.html#enum.StrEnum
