### PR TITLE
Mark extension as free-threading compatible & resolve Python-level issues

### DIFF
--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -8,10 +8,6 @@ from .nodes import *
 from .loader import *
 from .dumper import *
 
-from .constructor import setup_constructors
-from .representer import setup_representers
-from .resolver import setup_resolvers
-
 __version__ = '7.0.0.dev0'
 try:
     from .cyaml import *

--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -10,6 +10,7 @@ from .dumper import *
 
 from .constructor import setup_constructors
 from .representer import setup_representers
+from .resolver import setup_resolvers
 
 __version__ = '7.0.0.dev0'
 try:

--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -9,6 +9,7 @@ from .loader import *
 from .dumper import *
 
 from .constructor import setup_constructors
+from .representer import setup_representers
 
 __version__ = '7.0.0.dev0'
 try:

--- a/lib/yaml/__init__.py
+++ b/lib/yaml/__init__.py
@@ -8,6 +8,8 @@ from .nodes import *
 from .loader import *
 from .dumper import *
 
+from .constructor import setup_constructors
+
 __version__ = '7.0.0.dev0'
 try:
     from .cyaml import *

--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -11,15 +11,45 @@ __all__ = [
 from .error import *
 from .nodes import *
 
+import threading
 import collections.abc, datetime, base64, binascii, re, sys, types
 
 class ConstructorError(MarkedYAMLError):
     pass
 
-class BaseConstructor:
 
-    yaml_constructors = {}
-    yaml_multi_constructors = {}
+class ConstructorSetup(threading.local):
+    def __init__(self):
+        self.initialized = False
+
+    def ensure_initialized(self):
+        if not self.initialized:
+            self.initialized = True
+            setup_constructors()
+
+
+class ConstructorRegistry(threading.local):
+    def __init__(self):
+        self.yaml_constructors = {}
+        self.yaml_constructors_initialized = False
+        self.yaml_multi_constructors = {}
+        self.yaml_multi_constructors_initialized = False
+
+
+class ConstructorMeta(type):
+    """Metaclass to handle constructor registry inheritance"""
+    
+    def __new__(mcs, name, bases, attrs):
+        cls = super().__new__(mcs, name, bases, attrs)
+        if 'constructor_registry' not in cls.__dict__:
+            cls.constructor_registry = ConstructorRegistry()
+        return cls
+
+
+class BaseConstructor(metaclass=ConstructorMeta):
+
+    constructor_setup = ConstructorSetup() 
+    constructor_registry = ConstructorRegistry()
 
     def __init__(self):
         self.constructed_objects = {}
@@ -76,20 +106,22 @@ class BaseConstructor:
         self.recursive_objects[node] = None
         constructor = None
         tag_suffix = None
-        if node.tag in self.yaml_constructors:
-            constructor = self.yaml_constructors[node.tag]
+        yaml_constructors = self.yaml_constructors()
+        yaml_multi_constructors = self.yaml_multi_constructors()
+        if node.tag in yaml_constructors:
+            constructor = yaml_constructors[node.tag]
         else:
-            for tag_prefix in self.yaml_multi_constructors:
+            for tag_prefix in yaml_multi_constructors:
                 if tag_prefix is not None and node.tag.startswith(tag_prefix):
                     tag_suffix = node.tag[len(tag_prefix):]
-                    constructor = self.yaml_multi_constructors[tag_prefix]
+                    constructor = yaml_multi_constructors[tag_prefix]
                     break
             else:
-                if None in self.yaml_multi_constructors:
+                if None in yaml_multi_constructors:
                     tag_suffix = node.tag
-                    constructor = self.yaml_multi_constructors[None]
-                elif None in self.yaml_constructors:
-                    constructor = self.yaml_constructors[None]
+                    constructor = yaml_multi_constructors[None]
+                elif None in yaml_constructors:
+                    constructor = yaml_constructors[None]
                 elif isinstance(node, ScalarNode):
                     constructor = self.__class__.construct_scalar
                 elif isinstance(node, SequenceNode):
@@ -157,16 +189,52 @@ class BaseConstructor:
         return pairs
 
     @classmethod
+    def yaml_constructors(cls):
+        cls.constructor_setup.ensure_initialized()
+
+        # In case we're calling BaseConstructor.yaml_constructors, we should return the registry
+        # of the BaseConstructor class directly, since we don't need to go up the mro anymore
+        if cls.constructor_registry.yaml_constructors_initialized or cls is BaseConstructor:
+            return cls.constructor_registry.yaml_constructors
+
+        constructor_cls = next(
+            c for c in cls.mro() if hasattr(c, 'yaml_constructors') and c is not cls)
+        return constructor_cls.yaml_constructors()
+
+    @classmethod
+    def yaml_multi_constructors(cls):
+        cls.constructor_setup.ensure_initialized()
+
+        # In case we're calling BaseConstructor.yaml_multi_constructors, we should return the registry
+        # of the BaseConstructor class directly, since we don't need to go up the mro anymore
+        if cls.constructor_registry.yaml_multi_constructors_initialized or cls is BaseConstructor:
+            return cls.constructor_registry.yaml_multi_constructors
+
+        constructor_cls = next(
+            c for c in cls.mro() if hasattr(c, 'yaml_multi_constructors') and c is not cls)
+        return constructor_cls.yaml_multi_constructors()
+
+    @classmethod
+    def _ensure_yaml_constructors_initialized(cls):
+        if not cls.constructor_registry.yaml_constructors_initialized:
+            cls.constructor_registry.yaml_constructors = cls.yaml_constructors().copy()
+            cls.constructor_registry.yaml_constructors_initialized = True
+
+    @classmethod
+    def _ensure_yaml_multi_constructors_initialized(cls):
+        if not cls.constructor_registry.yaml_multi_constructors_initialized:
+            cls.constructor_registry.yaml_multi_constructors = cls.yaml_multi_constructors().copy()
+            cls.constructor_registry.yaml_multi_constructors_initialized = True
+
+    @classmethod
     def add_constructor(cls, tag, constructor):
-        if not 'yaml_constructors' in cls.__dict__:
-            cls.yaml_constructors = cls.yaml_constructors.copy()
-        cls.yaml_constructors[tag] = constructor
+        cls._ensure_yaml_constructors_initialized()
+        cls.constructor_registry.yaml_constructors[tag] = constructor
 
     @classmethod
     def add_multi_constructor(cls, tag_prefix, multi_constructor):
-        if not 'yaml_multi_constructors' in cls.__dict__:
-            cls.yaml_multi_constructors = cls.yaml_multi_constructors.copy()
-        cls.yaml_multi_constructors[tag_prefix] = multi_constructor
+        cls._ensure_yaml_multi_constructors_initialized()
+        cls.constructor_registry.yaml_multi_constructors[tag_prefix] = multi_constructor
 
 class SafeConstructor(BaseConstructor):
 
@@ -428,56 +496,6 @@ class SafeConstructor(BaseConstructor):
                 "could not determine a constructor for the tag %r" % node.tag,
                 node.start_mark)
 
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:null',
-        SafeConstructor.construct_yaml_null)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:bool',
-        SafeConstructor.construct_yaml_bool)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:int',
-        SafeConstructor.construct_yaml_int)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:float',
-        SafeConstructor.construct_yaml_float)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:binary',
-        SafeConstructor.construct_yaml_binary)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:timestamp',
-        SafeConstructor.construct_yaml_timestamp)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:omap',
-        SafeConstructor.construct_yaml_omap)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:pairs',
-        SafeConstructor.construct_yaml_pairs)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:set',
-        SafeConstructor.construct_yaml_set)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:str',
-        SafeConstructor.construct_yaml_str)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:seq',
-        SafeConstructor.construct_yaml_seq)
-
-SafeConstructor.add_constructor(
-        'tag:yaml.org,2002:map',
-        SafeConstructor.construct_yaml_map)
-
-SafeConstructor.add_constructor(None,
-        SafeConstructor.construct_undefined)
 
 class FullConstructor(SafeConstructor):
     # 'extend' is blacklisted because it is used by
@@ -658,57 +676,6 @@ class FullConstructor(SafeConstructor):
     def construct_python_object_new(self, suffix, node):
         return self.construct_python_object_apply(suffix, node, newobj=True)
 
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/none',
-    FullConstructor.construct_yaml_null)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/bool',
-    FullConstructor.construct_yaml_bool)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/str',
-    FullConstructor.construct_python_str)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/unicode',
-    FullConstructor.construct_python_unicode)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/bytes',
-    FullConstructor.construct_python_bytes)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/int',
-    FullConstructor.construct_yaml_int)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/long',
-    FullConstructor.construct_python_long)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/float',
-    FullConstructor.construct_yaml_float)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/complex',
-    FullConstructor.construct_python_complex)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/list',
-    FullConstructor.construct_yaml_seq)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/tuple',
-    FullConstructor.construct_python_tuple)
-
-FullConstructor.add_constructor(
-    'tag:yaml.org,2002:python/dict',
-    FullConstructor.construct_yaml_map)
-
-FullConstructor.add_multi_constructor(
-    'tag:yaml.org,2002:python/name:',
-    FullConstructor.construct_python_name)
 
 class UnsafeConstructor(FullConstructor):
 
@@ -726,23 +693,130 @@ class UnsafeConstructor(FullConstructor):
         return super(UnsafeConstructor, self).set_python_instance_state(
             instance, state, unsafe=True)
 
-UnsafeConstructor.add_multi_constructor(
-    'tag:yaml.org,2002:python/module:',
-    UnsafeConstructor.construct_python_module)
-
-UnsafeConstructor.add_multi_constructor(
-    'tag:yaml.org,2002:python/object:',
-    UnsafeConstructor.construct_python_object)
-
-UnsafeConstructor.add_multi_constructor(
-    'tag:yaml.org,2002:python/object/new:',
-    UnsafeConstructor.construct_python_object_new)
-
-UnsafeConstructor.add_multi_constructor(
-    'tag:yaml.org,2002:python/object/apply:',
-    UnsafeConstructor.construct_python_object_apply)
 
 # Constructor is same as UnsafeConstructor. Need to leave this in place in case
 # people have extended it directly.
 class Constructor(UnsafeConstructor):
     pass
+
+
+def setup_constructors():
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:null',
+        SafeConstructor.construct_yaml_null)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:bool',
+        SafeConstructor.construct_yaml_bool)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:int',
+        SafeConstructor.construct_yaml_int)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:float',
+        SafeConstructor.construct_yaml_float)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:binary',
+        SafeConstructor.construct_yaml_binary)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:timestamp',
+        SafeConstructor.construct_yaml_timestamp)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:omap',
+        SafeConstructor.construct_yaml_omap)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:pairs',
+        SafeConstructor.construct_yaml_pairs)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:set',
+        SafeConstructor.construct_yaml_set)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:str',
+        SafeConstructor.construct_yaml_str)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:seq',
+        SafeConstructor.construct_yaml_seq)
+
+    SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:map',
+        SafeConstructor.construct_yaml_map)
+
+    SafeConstructor.add_constructor(
+        None,
+        SafeConstructor.construct_undefined)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/none',
+        FullConstructor.construct_yaml_null)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/bool',
+        FullConstructor.construct_yaml_bool)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/str',
+        FullConstructor.construct_python_str)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/unicode',
+        FullConstructor.construct_python_unicode)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/bytes',
+        FullConstructor.construct_python_bytes)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/int',
+        FullConstructor.construct_yaml_int)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/long',
+        FullConstructor.construct_python_long)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/float',
+        FullConstructor.construct_yaml_float)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/complex',
+        FullConstructor.construct_python_complex)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/list',
+        FullConstructor.construct_yaml_seq)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/tuple',
+        FullConstructor.construct_python_tuple)
+
+    FullConstructor.add_constructor(
+        'tag:yaml.org,2002:python/dict',
+        FullConstructor.construct_yaml_map)
+
+    FullConstructor.add_multi_constructor(
+        'tag:yaml.org,2002:python/name:',
+        FullConstructor.construct_python_name)
+
+    UnsafeConstructor.add_multi_constructor(
+        'tag:yaml.org,2002:python/module:',
+        UnsafeConstructor.construct_python_module)
+
+    UnsafeConstructor.add_multi_constructor(
+        'tag:yaml.org,2002:python/object:',
+        UnsafeConstructor.construct_python_object)
+
+    UnsafeConstructor.add_multi_constructor(
+        'tag:yaml.org,2002:python/object/new:',
+        UnsafeConstructor.construct_python_object_new)
+
+    UnsafeConstructor.add_multi_constructor(
+        'tag:yaml.org,2002:python/object/apply:',
+        UnsafeConstructor.construct_python_object_apply)

--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -23,11 +23,11 @@ class RepresenterSetup(threading.local):
 
 
 class RepresenterRegistry(threading.local):
-    def __init__(self):
+    def __init__(self, yaml_representers_initialized=False, yaml_multi_representers_initialized=False):
         self.yaml_representers = {}
         self.yaml_multi_representers = {}
-        self.yaml_representers_initialized = False
-        self.yaml_multi_representers_initialized = False
+        self.yaml_representers_initialized = yaml_representers_initialized
+        self.yaml_multi_representers_initialized = yaml_multi_representers_initialized
 
 
 class RepresenterMeta(type):
@@ -43,7 +43,7 @@ class RepresenterMeta(type):
 class BaseRepresenter(metaclass=RepresenterMeta):
 
     representer_setup = RepresenterSetup()
-    representer_registry = RepresenterRegistry()
+    representer_registry = RepresenterRegistry(yaml_representers_initialized=True, yaml_multi_representers_initialized=True)
 
     def __init__(self, default_style=None, default_flow_style=False, sort_keys=True):
         self.default_style = default_style
@@ -98,28 +98,20 @@ class BaseRepresenter(metaclass=RepresenterMeta):
     def yaml_representers(cls):
         cls.representer_setup.ensure_initialized()
 
-        # In case we're calling BaseConstructor.get_registry, we should return the registry
-        # of the BaseConstructor class directly, since we don't need to go up the mro
-        if cls.representer_registry.yaml_representers_initialized or cls is BaseRepresenter:
+        if cls.representer_registry.yaml_representers_initialized:
             return cls.representer_registry.yaml_representers
 
-        # Otherwise, we need to find to return the registry of the parent class
-        constructor_cls = next(
-            c for c in cls.mro() if hasattr(c, 'yaml_representers') and c is not cls)
+        constructor_cls = next(c for c in cls.mro() if hasattr(c, 'yaml_representers') and c is not cls)
         return constructor_cls.yaml_representers()
 
     @classmethod
     def yaml_multi_representers(cls):
         cls.representer_setup.ensure_initialized()
 
-        # In case we're calling BaseConstructor.get_registry, we should return the registry
-        # of the BaseConstructor class directly, since we don't need to go up the mro
-        if cls.representer_registry.yaml_multi_representers_initialized or cls is BaseRepresenter:
+        if cls.representer_registry.yaml_multi_representers_initialized:
             return cls.representer_registry.yaml_multi_representers
 
-        # Otherwise, we need to find to return the registry of the parent class
-        constructor_cls = next(
-            c for c in cls.mro() if hasattr(c, 'yaml_multi_representers') and c is not cls)
+        constructor_cls = next(c for c in cls.mro() if hasattr(c, 'yaml_multi_representers') and c is not cls)
         return constructor_cls.yaml_multi_representers()
 
     @classmethod

--- a/lib/yaml/resolver.py
+++ b/lib/yaml/resolver.py
@@ -5,34 +5,104 @@ from .error import *
 from .nodes import *
 
 import re
+import threading
 
 class ResolverError(YAMLError):
     pass
 
-class BaseResolver:
+
+class ResolverSetup(threading.local):
+    def __init__(self):
+        self.initialized = False
+
+    def ensure_initialized(self):
+        if not self.initialized:
+            self.initialized = True
+            setup_resolvers()
+
+
+class ResolverRegistry(threading.local):
+    def __init__(self):
+        self.yaml_implicit_resolvers = {}
+        self.yaml_path_resolvers = {}
+        self.yaml_implicit_resolvers_initialized = False
+        self.yaml_path_resolvers_initialized = False
+
+
+class ResolverMeta(type):
+    """Metaclass to handle constructor registry inheritance"""
+    
+    def __new__(mcs, name, bases, attrs):
+        cls = super().__new__(mcs, name, bases, attrs)
+        if 'resolver_registry' not in cls.__dict__:
+            cls.resolver_registry = ResolverRegistry()
+        return cls
+
+
+class BaseResolver(metaclass=ResolverMeta):
 
     DEFAULT_SCALAR_TAG = 'tag:yaml.org,2002:str'
     DEFAULT_SEQUENCE_TAG = 'tag:yaml.org,2002:seq'
     DEFAULT_MAPPING_TAG = 'tag:yaml.org,2002:map'
 
-    yaml_implicit_resolvers = {}
-    yaml_path_resolvers = {}
+    resolver_setup = ResolverSetup()
+    resolver_registry = ResolverRegistry()
 
     def __init__(self):
         self.resolver_exact_paths = []
         self.resolver_prefix_paths = []
 
     @classmethod
+    def yaml_implicit_resolvers(cls):
+        cls.resolver_setup.ensure_initialized()
+
+        # In case we're calling BaseConstructor.get_registry, we should return the registry
+        # of the BaseConstructor class directly, since we don't need to go up the mro
+        if cls.resolver_registry.yaml_implicit_resolvers_initialized or cls is BaseResolver:
+            return cls.resolver_registry.yaml_implicit_resolvers
+
+        # Otherwise, we need to find to return the registry of the parent class
+        constructor_cls = next(
+            c for c in cls.mro() if hasattr(c, 'yaml_implicit_resolvers') and c is not cls)
+        return constructor_cls.yaml_implicit_resolvers()
+
+    @classmethod
+    def yaml_path_resolvers(cls):
+        cls.resolver_setup.ensure_initialized()
+
+        # In case we're calling BaseConstructor.get_registry, we should return the registry
+        # of the BaseConstructor class directly, since we don't need to go up the mro
+        if cls.resolver_registry.yaml_path_resolvers_initialized or cls is BaseResolver:
+            return cls.resolver_registry.yaml_path_resolvers
+
+        # Otherwise, we need to find to return the registry of the parent class
+        constructor_cls = next(
+            c for c in cls.mro() if hasattr(c, 'yaml_path_resolvers') and c is not cls)
+        return constructor_cls.yaml_path_resolvers()
+
+    @classmethod
+    def _ensure_yaml_implicit_resolvers_initialized(cls):
+        if not cls.resolver_registry.yaml_implicit_resolvers_initialized:
+            new_yaml_implicit_resolvers = {}
+            old_yaml_implicit_resolvers = cls.yaml_implicit_resolvers()
+            for key in old_yaml_implicit_resolvers:
+                new_yaml_implicit_resolvers[key] = old_yaml_implicit_resolvers[key][:]
+            cls.resolver_registry.yaml_implicit_resolvers = new_yaml_implicit_resolvers
+            cls.resolver_registry.yaml_implicit_resolvers_initialized = True
+
+    @classmethod
+    def _ensure_yaml_path_resolvers_initialized(cls):
+        if not cls.resolver_registry.yaml_path_resolvers_initialized:
+            cls.resolver_registry.yaml_path_resolvers = cls.yaml_path_resolvers().copy()
+            cls.resolver_registry.yaml_path_resolvers_initialized = True
+
+    @classmethod
     def add_implicit_resolver(cls, tag, regexp, first):
-        if not 'yaml_implicit_resolvers' in cls.__dict__:
-            implicit_resolvers = {}
-            for key in cls.yaml_implicit_resolvers:
-                implicit_resolvers[key] = cls.yaml_implicit_resolvers[key][:]
-            cls.yaml_implicit_resolvers = implicit_resolvers
+        cls._ensure_yaml_implicit_resolvers_initialized()
         if first is None:
             first = [None]
         for ch in first:
-            cls.yaml_implicit_resolvers.setdefault(ch, []).append((tag, regexp))
+            cls.resolver_registry.yaml_implicit_resolvers.setdefault(ch, []).append((tag, regexp))
 
     @classmethod
     def add_path_resolver(cls, tag, path, kind=None):
@@ -48,8 +118,7 @@ class BaseResolver:
         # a mapping value that corresponds to a scalar key which content is
         # equal to the `index_check` value.  An integer `index_check` matches
         # against a sequence value with the index equal to `index_check`.
-        if not 'yaml_path_resolvers' in cls.__dict__:
-            cls.yaml_path_resolvers = cls.yaml_path_resolvers.copy()
+        cls._ensure_yaml_path_resolvers_initialized()
         new_path = []
         for element in path:
             if isinstance(element, (list, tuple)):
@@ -86,10 +155,11 @@ class BaseResolver:
         elif kind not in [ScalarNode, SequenceNode, MappingNode]    \
                 and kind is not None:
             raise ResolverError("Invalid node kind: %s" % kind)
-        cls.yaml_path_resolvers[tuple(new_path), kind] = tag
+        cls.resolver_registry.yaml_path_resolvers[tuple(new_path), kind] = tag
 
     def descend_resolver(self, current_node, current_index):
-        if not self.yaml_path_resolvers:
+        yaml_path_resolvers = self.yaml_path_resolvers()
+        if not yaml_path_resolvers:
             return
         exact_paths = {}
         prefix_paths = []
@@ -101,18 +171,18 @@ class BaseResolver:
                     if len(path) > depth:
                         prefix_paths.append((path, kind))
                     else:
-                        exact_paths[kind] = self.yaml_path_resolvers[path, kind]
+                        exact_paths[kind] = yaml_path_resolvers[path, kind]
         else:
-            for path, kind in self.yaml_path_resolvers:
+            for path, kind in yaml_path_resolvers:
                 if not path:
-                    exact_paths[kind] = self.yaml_path_resolvers[path, kind]
+                    exact_paths[kind] = yaml_path_resolvers[path, kind]
                 else:
                     prefix_paths.append((path, kind))
         self.resolver_exact_paths.append(exact_paths)
         self.resolver_prefix_paths.append(prefix_paths)
 
     def ascend_resolver(self):
-        if not self.yaml_path_resolvers:
+        if not self.yaml_path_resolvers():
             return
         self.resolver_exact_paths.pop()
         self.resolver_prefix_paths.pop()
@@ -141,17 +211,19 @@ class BaseResolver:
         return True
 
     def resolve(self, kind, value, implicit):
+        yaml_implicit_resolvers = self.yaml_implicit_resolvers()
+        yaml_path_resolvers = self.yaml_path_resolvers()
         if kind is ScalarNode and implicit[0]:
             if value == '':
-                resolvers = self.yaml_implicit_resolvers.get('', [])
+                resolvers = yaml_implicit_resolvers.get('', [])
             else:
-                resolvers = self.yaml_implicit_resolvers.get(value[0], [])
-            wildcard_resolvers = self.yaml_implicit_resolvers.get(None, [])
+                resolvers = yaml_implicit_resolvers.get(value[0], [])
+            wildcard_resolvers = yaml_implicit_resolvers.get(None, [])
             for tag, regexp in resolvers + wildcard_resolvers:
                 if regexp.match(value):
                     return tag
             implicit = implicit[1]
-        if self.yaml_path_resolvers:
+        if yaml_path_resolvers:
             exact_paths = self.resolver_exact_paths[-1]
             if kind in exact_paths:
                 return exact_paths[kind]
@@ -167,61 +239,65 @@ class BaseResolver:
 class Resolver(BaseResolver):
     pass
 
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:bool',
-        re.compile(r'''^(?:yes|Yes|YES|no|No|NO
-                    |true|True|TRUE|false|False|FALSE
-                    |on|On|ON|off|Off|OFF)$''', re.X),
-        list('yYnNtTfFoO'))
 
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:float',
-        re.compile(r'''^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+][0-9]+)?
-                    |\.[0-9][0-9_]*(?:[eE][-+][0-9]+)?
-                    |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*
-                    |[-+]?\.(?:inf|Inf|INF)
-                    |\.(?:nan|NaN|NAN))$''', re.X),
-        list('-+0123456789.'))
+def setup_resolvers():
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:bool',
+            re.compile(r'''^(?:yes|Yes|YES|no|No|NO
+                        |true|True|TRUE|false|False|FALSE
+                        |on|On|ON|off|Off|OFF)$''', re.X),
+            list('yYnNtTfFoO'))
 
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:int',
-        re.compile(r'''^(?:[-+]?0b[0-1_]+
-                    |[-+]?0[0-7_]+
-                    |[-+]?(?:0|[1-9][0-9_]*)
-                    |[-+]?0x[0-9a-fA-F_]+
-                    |[-+]?[1-9][0-9_]*(?::[0-5]?[0-9])+)$''', re.X),
-        list('-+0123456789'))
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:float',
+            re.compile(r'''^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+][0-9]+)?
+                        |\.[0-9][0-9_]*(?:[eE][-+][0-9]+)?
+                        |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*
+                        |[-+]?\.(?:inf|Inf|INF)
+                        |\.(?:nan|NaN|NAN))$''', re.X),
+            list('-+0123456789.'))
 
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:merge',
-        re.compile(r'^(?:<<)$'),
-        ['<'])
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:int',
+            re.compile(r'''^(?:[-+]?0b[0-1_]+
+                        |[-+]?0[0-7_]+
+                        |[-+]?(?:0|[1-9][0-9_]*)
+                        |[-+]?0x[0-9a-fA-F_]+
+                        |[-+]?[1-9][0-9_]*(?::[0-5]?[0-9])+)$''', re.X),
+            list('-+0123456789'))
 
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:null',
-        re.compile(r'''^(?: ~
-                    |null|Null|NULL
-                    | )$''', re.X),
-        ['~', 'n', 'N', ''])
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:merge',
+            re.compile(r'^(?:<<)$'),
+            ['<'])
 
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:timestamp',
-        re.compile(r'''^(?:[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]
-                    |[0-9][0-9][0-9][0-9] -[0-9][0-9]? -[0-9][0-9]?
-                     (?:[Tt]|[ \t]+)[0-9][0-9]?
-                     :[0-9][0-9] :[0-9][0-9] (?:\.[0-9]*)?
-                     (?:[ \t]*(?:Z|[-+][0-9][0-9]?(?::[0-9][0-9])?))?)$''', re.X),
-        list('0123456789'))
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:null',
+            re.compile(r'''^(?: ~
+                        |null|Null|NULL
+                        | )$''', re.X),
+            ['~', 'n', 'N', ''])
 
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:value',
-        re.compile(r'^(?:=)$'),
-        ['='])
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:timestamp',
+            re.compile(r'''^(?:[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]
+                        |[0-9][0-9][0-9][0-9] -[0-9][0-9]? -[0-9][0-9]?
+                        (?:[Tt]|[ \t]+)[0-9][0-9]?
+                        :[0-9][0-9] :[0-9][0-9] (?:\.[0-9]*)?
+                        (?:[ \t]*(?:Z|[-+][0-9][0-9]?(?::[0-9][0-9])?))?)$''', re.X),
+            list('0123456789'))
 
-# The following resolver is only for documentation purposes. It cannot work
-# because plain scalars cannot start with '!', '&', or '*'.
-Resolver.add_implicit_resolver(
-        'tag:yaml.org,2002:yaml',
-        re.compile(r'^(?:!|&|\*)$'),
-        list('!&*'))
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:value',
+            re.compile(r'^(?:=)$'),
+            ['='])
 
+    # The following resolver is only for documentation purposes. It cannot work
+    # because plain scalars cannot start with '!', '&', or '*'.
+    Resolver.add_implicit_resolver(
+            'tag:yaml.org,2002:yaml',
+            re.compile(r'^(?:!|&|\*)$'),
+            list('!&*'))
+
+
+setup_resolvers()

--- a/tests/free_threading/test_constructor.py
+++ b/tests/free_threading/test_constructor.py
@@ -1,0 +1,54 @@
+import io
+
+import yaml
+
+
+class MyLoader(yaml.CLoader):
+    pass
+
+
+class MyTestClass1:
+    def __init__(self, x, y=0, z=0):
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def __eq__(self, other):
+        if isinstance(other, MyTestClass1):
+            return self.__class__, self.__dict__ == other.__class__, other.__dict__
+        else:
+            return False
+
+    def __repr__(self):
+        return f"MyTestClass1(x={self.x}, y={self.y}, z={self.z})"
+
+
+def construct1(constructor, node):
+    mapping = constructor.construct_mapping(node)
+    return MyTestClass1(**mapping)
+
+
+def test_default_constructors_registered():
+    yamlcode = io.StringIO("""\
+- !!python/tuple [hello, world]
+""")
+
+    objs = yaml.load(yamlcode, Loader=yaml.CLoader)
+    assert objs == [("hello", "world")]
+
+
+def test_constructor_registration():
+    yaml.add_constructor("!tag1", construct1, Loader=MyLoader)
+
+    yamlcode = io.StringIO("""\
+- !tag1
+  x: 1
+- !tag1
+  x: 1
+  'y': 2
+  z: 3
+""")
+
+    objs = yaml.load(yamlcode, Loader=MyLoader)
+    assert objs == [MyTestClass1(x=1), MyTestClass1(x=1, y=2, z=3)]
+    del MyLoader.yaml_constructors()["!tag1"]

--- a/tests/free_threading/test_representer.py
+++ b/tests/free_threading/test_representer.py
@@ -1,0 +1,51 @@
+import yaml
+
+
+class MyDumper(yaml.CDumper):
+    pass
+
+
+class MyTestClass1:
+    def __init__(self, x, y=0, z=0):
+        self.x = x
+        self.y = y
+        self.z = z
+    def __eq__(self, other):
+        if isinstance(other, MyTestClass1):
+            return self.__class__, self.__dict__ == other.__class__, other.__dict__
+        else:
+            return False
+
+
+def represent1(representer, native):
+    return representer.represent_mapping("!tag1", native.__dict__)
+
+
+def test_default_representers_registered():
+    obj = [("hello", "world")]
+
+    yamlcode = yaml.dump(obj, Dumper=yaml.CDumper)
+    assert yamlcode == """\
+- !!python/tuple
+  - hello
+  - world
+"""
+
+
+def test_representer_registration():
+    yaml.add_representer(MyTestClass1, represent1, Dumper=MyDumper)
+
+    obj = [MyTestClass1(x=1), MyTestClass1(x=1, y=2, z=3)]
+
+    yamlcode = yaml.dump(obj, Dumper=MyDumper)
+    assert yamlcode == """\
+- !tag1
+  x: 1
+  y: 0
+  z: 0
+- !tag1
+  x: 1
+  y: 2
+  z: 3
+"""
+    del MyDumper.yaml_representers()[MyTestClass1]

--- a/tests/free_threading/test_resolver.py
+++ b/tests/free_threading/test_resolver.py
@@ -1,0 +1,117 @@
+import re
+import yaml
+
+
+class Dice(tuple):
+    def __new__(cls, a, b):
+        return tuple.__new__(cls, (a, b))
+
+    def __repr__(self):
+        return "Dice(%s,%s)" % self
+
+
+def dice_representer(dumper, data):
+    return dumper.represent_scalar("!dice", "%sd%s" % data)
+
+
+def _convert_node(node):
+    if isinstance(node, yaml.ScalarNode):
+        return (node.tag, node.value)
+    elif isinstance(node, yaml.SequenceNode):
+        value = []
+        for item in node.value:
+            value.append(_convert_node(item))
+        return (node.tag, value)
+    elif isinstance(node, yaml.MappingNode):
+        value = []
+        for key, item in node.value:
+            value.append((_convert_node(key), _convert_node(item)))
+        return (node.tag, value)
+
+
+def test_default_implicit_resolvers_registered():
+    yamlcode = """\
+- [1, 2, 3]
+- 2
+"""
+
+    node = yaml.compose(yamlcode, Loader=yaml.CLoader)
+    assert isinstance(node, yaml.SequenceNode)
+    assert isinstance(node.value[0], yaml.SequenceNode)
+    for scalar in node.value[0].value:
+        assert isinstance(scalar, yaml.ScalarNode)
+        assert scalar.tag == 'tag:yaml.org,2002:int'
+    assert isinstance(node.value[1], yaml.ScalarNode)
+    assert node.value[1].tag == 'tag:yaml.org,2002:int'
+
+
+class ImplicitResolverLoader(yaml.CLoader):
+    pass
+
+
+class ImplicitResolverDumper(yaml.CDumper):
+    pass
+
+
+def test_implicit_resolver_registration():
+    yaml.add_representer(Dice, dice_representer, Dumper=ImplicitResolverDumper)
+    yaml.add_implicit_resolver('!dice', re.compile(r'^\d+d\d+$'), Loader=ImplicitResolverLoader, Dumper=ImplicitResolverDumper)
+
+    yamlcode = """\
+- 1d4
+- 2d6
+- 3d8
+"""
+    node = yaml.compose(yamlcode, Loader=ImplicitResolverLoader)
+    assert isinstance(node, yaml.SequenceNode)
+    for scalar in node.value:
+        assert isinstance(scalar, yaml.ScalarNode)
+        assert scalar.tag == '!dice'
+
+
+class PathResolverLoader(yaml.CLoader):
+    pass
+
+
+class PathResolverDumper(yaml.CDumper):
+    pass
+
+
+def test_path_resolver_loader():
+    yaml.add_path_resolver('!root', [],
+            Loader=PathResolverLoader, Dumper=PathResolverDumper)
+    yaml.add_path_resolver('!root/scalar', [], str,
+            Loader=PathResolverLoader, Dumper=PathResolverDumper)
+    yaml.add_path_resolver('!root/key11/key12/*', ['key11', 'key12'],
+            Loader=PathResolverLoader, Dumper=PathResolverDumper)
+
+    yamlcode = """\
+---
+"this scalar should be selected"
+---
+key11: !foo
+    key12:
+        is: [selected]
+    key22:
+        key13: [not, selected]
+        key23: [not, selected]
+"""
+
+    resolved_yamlcode = """\
+--- !root/scalar
+"this scalar should be selected"
+--- !root
+key11: !foo
+    key12: !root/key11/key12/*
+        is: [selected]
+    key22:
+        key13: [not, selected]
+        key23: [not, selected]
+"""
+
+    nodes1 = list(yaml.compose_all(yamlcode, Loader=PathResolverLoader))
+    nodes2 = list(yaml.compose_all(resolved_yamlcode, Loader=PathResolverLoader))
+    for node1, node2 in zip(nodes1, nodes2):
+        data1 = _convert_node(node1)
+        data2 = _convert_node(node2)
+        assert data1 == data2

--- a/tests/free_threading/test_stress.py
+++ b/tests/free_threading/test_stress.py
@@ -1,0 +1,180 @@
+import random
+import re
+import threading
+
+import yaml
+
+
+class Dice(tuple):
+    def __new__(cls, a, b):
+        return tuple.__new__(cls, (a, b))
+
+    def __repr__(self):
+        return "Dice(%s,%s)" % self
+
+
+def dice_constructor(loader, node):
+    value = loader.construct_scalar(node)
+    a, b = map(int, value.split('d'))
+    return Dice(a, b)
+
+
+def dice_representer(dumper, data):
+    return dumper.represent_scalar("!dice", "%sd%s" % data)
+
+
+# Different YAML content types for testing
+YAML_LOAD_SAMPLES = [
+    # Simple key-value pairs
+    ("""\
+key1: value1
+key2: value2
+key3: 123
+key4: true
+""", {
+        "key1": "value1",
+        "key2": "value2",
+        "key3": 123,
+        "key4": True
+    }),
+    
+    # Nested structures
+    ("""\
+config:
+  database:
+    host: localhost
+    port: 5432
+    credentials:
+      username: admin
+      password: secret
+  logging:
+    level: INFO
+    file: /var/log/app.log
+""", {
+        "config": {
+            "database": {
+                "host": "localhost",
+                "port": 5432,
+                "credentials": {
+                    "username": "admin",
+                    "password": "secret"
+                }
+            },
+            "logging": {
+                "level": "INFO",
+                "file": "/var/log/app.log"
+            }
+        }
+    }),
+
+    # Lists
+    ("""\
+fruits:
+  - apple
+  - banana
+  - orange
+numbers: [1, 2, 3, 4, 5]
+mixed:
+  - name: John
+    age: 30
+  - name: Alice
+    age: 25
+""", {
+        "fruits": ["apple", "banana", "orange"],
+        "numbers": [1, 2, 3, 4, 5],
+        "mixed": [
+            {"name": "John", "age": 30},
+            {"name": "Alice", "age": 25}
+        ]
+    }),
+    
+    # Complex with references
+    ("""\
+defaults: &defaults
+  adapter: postgresql
+  host: localhost
+
+development:
+  database: myapp_development
+  <<: *defaults
+
+test:
+  database: myapp_test
+  <<: *defaults
+""", {
+        "defaults": {
+            "adapter": "postgresql",
+            "host": "localhost"
+        },
+        "development": {
+            "database": "myapp_development",
+            "adapter": "postgresql",
+            "host": "localhost"
+        },
+        "test": {
+            "database": "myapp_test",
+            "adapter": "postgresql",
+            "host": "localhost"
+        }
+    }),
+
+    # Dice with resolver
+    ("""\
+rolls_resolver:
+  - 1d6
+  - 2d4
+  - 3d1
+""", {
+        "rolls_resolver": [
+            Dice(1, 6),
+            Dice(2, 4),
+            Dice(3, 1)
+        ]
+    }),
+
+    # Dice without resolver
+    ("""\
+rolls_no_resolver:
+  - 1d6
+  - 2d4
+  - 3d1
+""", {
+        "rolls_no_resolver": [
+            "1d6",
+            "2d4",
+            "3d1"
+        ]
+    }),
+]
+
+
+class MyLoader(yaml.CLoader):
+    pass
+
+
+class MyDumper(yaml.CDumper):
+    pass
+
+
+def test_yaml_load_stress():
+    yamlcode, result = random.choice(YAML_LOAD_SAMPLES)
+    thread_id = threading.current_thread().name
+    randint = random.randint(1, 1000)
+    yamlcode += f"\nrandom_value_{thread_id}: {randint}"
+
+
+    constructor, resolver = False, False
+    if yamlcode.startswith("rolls"):
+        yaml.add_constructor("!dice", dice_constructor, Loader=MyLoader)
+        constructor = True
+        if yamlcode.startswith("rolls_resolver"):
+            yaml.add_implicit_resolver('!dice', re.compile(r'^\d+d\d+$'),
+                                        Loader=MyLoader, Dumper=MyDumper)
+            resolver = True
+
+    obj = yaml.load(yamlcode, Loader=MyLoader)
+    assert obj == {**result, f"random_value_{thread_id}": randint}
+    if constructor:
+        del MyLoader.yaml_constructors()["!dice"]
+    if resolver:
+        del MyLoader.yaml_implicit_resolvers()[None]

--- a/yaml/_yaml.pyx
+++ b/yaml/_yaml.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 
 import yaml
 


### PR DESCRIPTION
- After a few Cython and CPython fixes, and since the API does not allow for sharing `Dumper` / `Loader` classes, just marking the Cython extension as free-threading compatible is enough.
- For the Python-level issues the solution is the following:
	- For each `Constructor`, `Representer` or `Resolver` class, we introduce a thread-local registry that's a class attribute in earch class, and which holds all items that constructor/representer/resolver supports.
	- Every subclass automatically gets an uninitialized registry by using a metaclass.
	- Upon calling `add_constructor` (and friends) or `load/dump` (and friends) for the first time, the registry is populated with the default items.
	- In order to get the items in the registry we do the following:
		- If the registry has been initialized, we return the thread-local data.
		- If not, we go up the mro until we find a parent class with an initialized registry and return their items.