### PR TITLE
Fix #866: Add constructor for tag:yaml.org,2002:value

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -476,6 +476,10 @@ SafeConstructor.add_constructor(
         'tag:yaml.org,2002:map',
         SafeConstructor.construct_yaml_map)
 
+SafeConstructor.add_constructor(
+        'tag:yaml.org,2002:value',
+        SafeConstructor.construct_yaml_str)
+
 SafeConstructor.add_constructor(None,
         SafeConstructor.construct_undefined)
 


### PR DESCRIPTION
## Problem
PyYAML fails to parse YAML documents containing standalone `=` characters with:

This affects real-world use cases like Prometheus CRDs with enum values containing `=`.

## Root Cause
The YAML resolver correctly identifies standalone `=` as having the tag `tag:yaml.org,2002:value`, but no constructor was defined for this tag in the SafeConstructor class.

## Solution
- Added constructor mapping for `tag:yaml.org,2002:value` to `construct_yaml_str` 
- Treats standalone `=` as string scalar (consistent with YAML 1.1 specification)
- Minimal, targeted fix with no breaking changes
- Single line addition to `lib/yaml/constructor.py`

## Testing
- ✅ Verified fix works with SafeLoader, FullLoader, UnsafeLoader
- ✅ Tested with real-world Prometheus CRD YAML from the issue
- ✅ Tested edge cases: flow sequences, mappings, mixed quoting
- ✅ Verified no regressions in existing functionality
- ✅ Test Script
```py
import sys
import os
# Add the local lib directory to the path to use our modified version
sys.path.insert(0, os.path.join(os.getcwd(), 'lib'))

import requests
import yaml

url = "https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.83.0/stripped-down-crds.yaml"

# Download the spec
response = requests.get(url)
response.raise_for_status() 
res = response.text

# Parse multi-document YAML
documents = list(yaml.safe_load_all(res))
print("Parsed YAML documents:")
for i, doc in enumerate(documents, 1):
    print(f"\nDocument {i}:")
    print(doc)
```

## Files Changed
- `lib/yaml/constructor.py`: Added constructor for `tag:yaml.org,2002:value`

## Backwards Compatibility
✅ No breaking changes - only adds support for previously unsupported syntax

Fixes #866