### PR TITLE
allow riscv64 package wheel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,7 @@ jobs:
           - { platform: manylinux2014, arch: x86_64 }
           - { platform: manylinux2014, arch: aarch64 }
           - { platform: manylinux2014, arch: s390x, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }}  }
           - { platform: musllinux_1_2, arch: x86_64 }
           - { platform: musllinux_1_2, arch: aarch64 }
 
@@ -169,6 +170,12 @@ jobs:
           - { platform: manylinux2014, arch: s390x, spec: cp313, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp314, omit: ${{ env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp314t, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp38, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }}, cibw_version: cibuildwheel==3.1.3 }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }}, cibw_version: cibuildwheel==3.1.3 }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }}, cibw_version: cibuildwheel==3.1.3 }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }}, cibw_version: cibuildwheel==3.1.3 }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }}, cibw_version: cibuildwheel==3.1.3 }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp313, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }}, cibw_version: cibuildwheel==3.1.3 }
           - { platform: musllinux_1_2, arch: x86_64, spec: cp38, omit: ${{ env.skip_ci_redundant_jobs }} }
           - { platform: musllinux_1_2, arch: x86_64, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs }} }
           - { platform: musllinux_1_2, arch: x86_64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs }} }
@@ -228,6 +235,7 @@ jobs:
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_S390X_IMAGE: ${{ matrix.manylinux_img || '' }}
+        CIBW_MANYLINUX_RISCV64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MUSLLINUX_X86_64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
         CIBW_MUSLLINUX_I686_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
         CIBW_MUSLLINUX_AARCH64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}

--- a/packaging/build/libyaml.sh
+++ b/packaging/build/libyaml.sh
@@ -13,7 +13,11 @@ echo "::endgroup::"
 # ensure the prove testing tool is available
 echo "::group::ensure build/test prerequisites"
 if ! command -v prove; then
-  if grep -m 1 alpine /etc/os-release; then
+  if command -v dnf >/dev/null 2>&1; then
+    dnf install -y perl-Test-Harness
+  elif command -v apt-get >/dev/null 2>&1; then
+    apt-get update && apt-get install -y libtest-harness-perl
+  elif grep -m 1 alpine /etc/os-release; then
     apk add perl-utils
   else
     echo "prove (perl) testing tool unavailable"


### PR DESCRIPTION
PyPI recently added support for RISC-V, so we might consider adding support for RISC-V64.

Below are the CI results:
[PyYAML CI](https://github.com/ffgan/pyyaml/actions/runs/16717429466)

The results are generally well presented.

Other Info
Co-authored by: [nijincheng@iscas.ac.cn](mailto:nijincheng@iscas.ac.cn);