### PR TITLE
BLD: PEP 639 compliance (declare license-files)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include CHANGES README LICENSE Makefile pyproject.toml setup.py
+include CHANGES README Makefile pyproject.toml setup.py
 recursive-include lib/yaml *.py
 recursive-include lib/_yaml *.py
 recursive-include packaging *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools",  # FIXME: declare min/max setuptools versions?
+    "setuptools >=77.0.1",  # FIXME: declare max setuptools versions?
     "Cython; python_version < '3.13'",
     "Cython>=3.0; python_version >= '3.13'"
 ]

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ configuration files to object serialization and persistence."""
 AUTHOR = "Kirill Simonov"
 AUTHOR_EMAIL = 'xi@resolvent.net'
 LICENSE = "MIT"
+LICENSE_FILE = "LICENSE"
 PLATFORMS = "Any"
 URL = "https://pyyaml.org/"
 DOWNLOAD_URL = "https://pypi.org/project/PyYAML/"
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Cython",
     "Programming Language :: Python",
@@ -339,6 +339,7 @@ if __name__ == '__main__':
         author=AUTHOR,
         author_email=AUTHOR_EMAIL,
         license=LICENSE,
+        license_files=[LICENSE_FILE],
         platforms=PLATFORMS,
         url=URL,
         download_url=DOWNLOAD_URL,


### PR DESCRIPTION
Fixes the following build-time deprecation warning from setuptools:
```
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:

          License :: OSI Approved :: MIT License

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
```

support for PEP 639 was added in version 77.0.0
xref https://setuptools.pypa.io/en/latest/history.html#v77-0-0