### PR TITLE
SafeConstructor.yaml_flatteners, to enable pluggable flattening akin to add_constructors

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -20,6 +20,7 @@ class BaseConstructor:
 
     yaml_constructors = {}
     yaml_multi_constructors = {}
+    yaml_flatteners = {}
 
     def __init__(self):
         self.constructed_objects = {}
@@ -168,6 +169,12 @@ class BaseConstructor:
             cls.yaml_multi_constructors = cls.yaml_multi_constructors.copy()
         cls.yaml_multi_constructors[tag_prefix] = multi_constructor
 
+    @classmethod
+    def add_flattener(cls, tag, flattener):
+        if not 'yaml_flatteners' in cls.__dict__:
+            cls.yaml_flatteners = cls.yaml_flatteners.copy()
+        cls.yaml_flatteners[tag] = flattener
+
 class SafeConstructor(BaseConstructor):
 
     def construct_scalar(self, node):
@@ -184,21 +191,10 @@ class SafeConstructor(BaseConstructor):
             key_node, value_node = node.value[index]
             if key_node.tag == 'tag:yaml.org,2002:merge':
                 del node.value[index]
-                if isinstance(value_node, MappingNode):
-                    self.flatten_mapping(value_node)
-                    merge.extend(value_node.value)
-                elif isinstance(value_node, SequenceNode):
-                    submerge = []
-                    for subnode in value_node.value:
-                        if not isinstance(subnode, MappingNode):
-                            raise ConstructorError("while constructing a mapping",
-                                    node.start_mark,
-                                    "expected a mapping for merging, but found %s"
-                                    % subnode.id, subnode.start_mark)
-                        self.flatten_mapping(subnode)
-                        submerge.append(subnode.value)
-                    submerge.reverse()
-                    for value in submerge:
+
+                flattener = self.yaml_flatteners.get(value_node.tag)
+                if flattener:
+                    for value in flattener(self, value_node):
                         merge.extend(value)
                 else:
                     raise ConstructorError("while constructing a mapping", node.start_mark,
@@ -428,6 +424,25 @@ class SafeConstructor(BaseConstructor):
                 "could not determine a constructor for the tag %r" % node.tag,
                 node.start_mark)
 
+    def flatten_yaml_seq(self, node):
+        submerge = []
+        for subnode in node.value:
+            if not isinstance(subnode, MappingNode):
+                raise ConstructorError("while constructing a mapping",
+                        node.start_mark,
+                        "expected a mapping for merging, but found %s"
+                        % subnode.id, subnode.start_mark)
+            self.flatten_mapping(subnode)
+            submerge.append(subnode.value)
+        submerge.reverse()
+        for value in submerge:
+            yield value
+
+    def flatten_yaml_map(self, node):
+        self.flatten_mapping(node)
+        yield node.value
+
+
 SafeConstructor.add_constructor(
         'tag:yaml.org,2002:null',
         SafeConstructor.construct_yaml_null)
@@ -478,6 +493,14 @@ SafeConstructor.add_constructor(
 
 SafeConstructor.add_constructor(None,
         SafeConstructor.construct_undefined)
+
+SafeConstructor.add_flattener(
+        'tag:yaml.org,2002:seq',
+        SafeConstructor.flatten_yaml_seq)
+
+SafeConstructor.add_flattener(
+        'tag:yaml.org,2002:map',
+        SafeConstructor.flatten_yaml_map)
 
 class FullConstructor(SafeConstructor):
     # 'extend' is blacklisted because it is used by

--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -427,13 +427,18 @@ class SafeConstructor(BaseConstructor):
     def flatten_yaml_seq(self, node):
         submerge = []
         for subnode in node.value:
-            if not isinstance(subnode, MappingNode):
+            # we need to flatten each item in the seq, most likely they'll be mappings,
+            # but we need to allow for custom flatteners as well.
+            flattener = self.yaml_flatteners.get(subnode.tag)
+            if flattener:
+                for value in flattener(self, subnode):
+                    submerge.append(value)
+            else:
                 raise ConstructorError("while constructing a mapping",
                         node.start_mark,
                         "expected a mapping for merging, but found %s"
                         % subnode.id, subnode.start_mark)
-            self.flatten_mapping(subnode)
-            submerge.append(subnode.value)
+
         submerge.reverse()
         for value in submerge:
             yield value

--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -186,12 +186,8 @@ class SafeConstructor(BaseConstructor):
 
     def flatten_mapping(self, node):
         merge = []
-        index = 0
-        while index < len(node.value):
-            key_node, value_node = node.value[index]
+        for key_node, value_node in node.value:
             if key_node.tag == 'tag:yaml.org,2002:merge':
-                del node.value[index]
-
                 flattener = self.yaml_flatteners.get(value_node.tag)
                 if flattener:
                     for value in flattener(self, value_node):
@@ -200,13 +196,12 @@ class SafeConstructor(BaseConstructor):
                     raise ConstructorError("while constructing a mapping", node.start_mark,
                             "expected a mapping or list of mappings for merging, but found %s"
                             % value_node.id, value_node.start_mark)
-            elif key_node.tag == 'tag:yaml.org,2002:value':
-                key_node.tag = 'tag:yaml.org,2002:str'
-                index += 1
             else:
-                index += 1
-        if merge:
-            node.value = merge + node.value
+                if key_node.tag == 'tag:yaml.org,2002:value':
+                    key_node.tag = 'tag:yaml.org,2002:str'
+                merge.append((key_node, value_node))
+
+        node.value = merge
 
     def construct_mapping(self, node, deep=False):
         if isinstance(node, MappingNode):

--- a/tests/test_constructor_flattener.py
+++ b/tests/test_constructor_flattener.py
@@ -49,3 +49,86 @@ merged:
     assert result['merged']['y'] == 20
     assert result['merged']['z'] == 30
     assert result['merged']['label'] == 'test'
+
+
+def test_custom_flattener_with_sequence():
+    """
+    Test custom flattener with sequence of YAML strings (multiple merges).
+    """
+
+    def flatten_yaml_string(constructor, node):
+        if isinstance(node, yaml.ScalarNode):
+            yaml_string = constructor.construct_scalar(node)
+            parsed_node = yaml.compose(StringIO(yaml_string), yaml.SafeLoader)
+
+            if isinstance(parsed_node, yaml.MappingNode):
+                constructor.flatten_mapping(parsed_node)
+                yield parsed_node.value
+        else:
+            raise yaml.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "expected a string containing YAML for !yaml_string tag",
+                node.start_mark
+            )
+
+    class CustomLoader(yaml.SafeLoader):
+        pass
+
+    CustomLoader.add_flattener('!yaml_string', flatten_yaml_string)
+
+    test_yaml = """
+merged:
+  <<: [!yaml_string "x: 1", !yaml_string "y: 2", !yaml_string "z: 3"]
+  label: multi
+"""
+
+    result = yaml.load(test_yaml, CustomLoader)
+
+    assert result['merged']['x'] == 1
+    assert result['merged']['y'] == 2
+    assert result['merged']['z'] == 3
+    assert result['merged']['label'] == 'multi'
+
+
+def test_custom_flattener_override():
+    """
+    Test that later values override earlier ones in merge sequence.
+
+    It also lightly verifies that the original/standard MappingNode
+    inside of a sequence functions as expected.
+    """
+
+    def flatten_yaml_string(constructor, node):
+        if isinstance(node, yaml.ScalarNode):
+            yaml_string = constructor.construct_scalar(node)
+            parsed_node = yaml.compose(StringIO(yaml_string), yaml.SafeLoader)
+
+            if isinstance(parsed_node, yaml.MappingNode):
+                constructor.flatten_mapping(parsed_node)
+                yield parsed_node.value
+        else:
+            raise yaml.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "expected a string containing YAML for !yaml_string tag",
+                node.start_mark
+            )
+
+    class CustomLoader(yaml.SafeLoader):
+        pass
+
+    CustomLoader.add_flattener('!yaml_string', flatten_yaml_string)
+
+    test_yaml = """
+merged:
+  <<: [{x: 1, y: 2}, !yaml_string "x: 10"]
+  x: 100
+  label: override
+"""
+
+    result = yaml.load(test_yaml, CustomLoader)
+
+    assert result['merged']['x'] == 100
+    assert result['merged']['y'] == 2
+    assert result['merged']['label'] == 'override'

--- a/tests/test_constructor_flattener.py
+++ b/tests/test_constructor_flattener.py
@@ -122,13 +122,17 @@ def test_custom_flattener_override():
 
     test_yaml = """
 merged:
-  <<: [{x: 1, y: 2}, !yaml_string "x: 10"]
-  x: 100
-  label: override
+  v: 0
+  w: overwritten
+  <<: [{w: 1, x: overwritten, y: 3}, !yaml_string "x: 10"]
+  x: 2
+  z: 4
 """
 
     result = yaml.load(test_yaml, CustomLoader)
 
-    assert result['merged']['x'] == 100
-    assert result['merged']['y'] == 2
-    assert result['merged']['label'] == 'override'
+    assert result['merged']['v'] == 0
+    assert result['merged']['w'] == 1
+    assert result['merged']['x'] == 2
+    assert result['merged']['y'] == 3
+    assert result['merged']['z'] == 4

--- a/tests/test_constructor_flattener.py
+++ b/tests/test_constructor_flattener.py
@@ -1,0 +1,51 @@
+import pytest
+import yaml
+from io import StringIO
+
+
+def test_custom_flattener_with_compose():
+    """
+    Test that a custom flattener can use compose to parse embedded YAML.
+    """
+
+    def flatten_yaml_string(constructor, node):
+        """
+        Flattener that parses YAML from a string scalar.
+        Used to test that custom flatteners can call compose.
+        """
+        if isinstance(node, yaml.ScalarNode):
+            yaml_string = constructor.construct_scalar(node)
+            parsed_node = yaml.compose(StringIO(yaml_string), yaml.SafeLoader)
+
+            if isinstance(parsed_node, yaml.MappingNode):
+                constructor.flatten_mapping(parsed_node)
+                yield parsed_node.value
+        else:
+            raise yaml.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "expected a string containing YAML for !yaml_string tag",
+                node.start_mark
+            )
+
+    class CustomLoader(yaml.SafeLoader):
+        pass
+
+    CustomLoader.add_flattener('!yaml_string', flatten_yaml_string)
+
+    test_yaml = """
+base:
+  x: 1
+  y: 2
+
+merged:
+  <<: !yaml_string "x: 10\\ny: 20\\nz: 30"
+  label: test
+"""
+
+    result = yaml.load(test_yaml, CustomLoader)
+
+    assert result['merged']['x'] == 10
+    assert result['merged']['y'] == 20
+    assert result['merged']['z'] == 30
+    assert result['merged']['label'] == 'test'


### PR DESCRIPTION
As part of working through https://github.com/octodns/octodns/pull/1315 I wanted to add support for `<<: !include some-file.yaml` and ran into the same problems as others: https://github.com/yaml/pyyaml/issues/632 and https://github.com/yaml/pyyaml/issues/814.

After a few false starts and unworkable ideas I landed on adding the ability to have pluggable flattening the same way that constructors are now. It's a fairly trivial change in the repo and I'm able to port the existing map and seq blocks over and have all the tests passing.

More interestingly it allows 3rd parties to add new flatteners, so in the case of `!include` I can do something like:

```python
class IncludingLoader(SafeLoader):

    def construct_include(self, node):
        mark = self.get_mark()
        directory = dirname(mark.name)

        filename = join(directory, self.construct_scalar(node))

        with open(filename, 'r') as fh:
            return load(fh, self.__class__)

    def flatten_include(self, node):
        mark = self.get_mark()
        directory = dirname(mark.name)

        filename = join(directory, self.construct_scalar(node))

        with open(filename, 'r') as fh:
            yield compose(fh, self.__class__).value

IncludingLoader.add_constructor('!include', IncludingLoader.construct_include)
IncludingLoader.add_flattener('!include', IncludingLoader.flatten_include)
```


In the context of octoDNS that allows config like:

```yaml
# octodns.yaml
...

_zones: &a
  first.com.:
    sources:
      - config
    targets:
      - out

zones:
  <<: *a

  <<: !include zones.yaml

  primary.com.:
    sources:
      - config
    processors:
      - ownership
    targets:
      - out
```

```yaml
# zones.yaml
---
other.com.:
  sources:
    - config
  targets:
    - out
```

To work exactly as expected.

I'm out of time for now, but I plan to come back to this PR and look at adding specific tests around the ability to add custom flatteners and verify that the more complex versions of `<<:` work, i.e. arrays and custom flatterers in anchors. 

Thoughts and suggestions welcomed.
