### PR TITLE
Accept `str` subclasses in SafeRepresenter (fixes support of enum.StrEnum)

### DIFF
--- a/lib/yaml/representer.py
+++ b/lib/yaml/representer.py
@@ -233,7 +233,7 @@ class SafeRepresenter(BaseRepresenter):
 SafeRepresenter.add_representer(type(None),
         SafeRepresenter.represent_none)
 
-SafeRepresenter.add_representer(str,
+SafeRepresenter.add_multi_representer(str,
         SafeRepresenter.represent_str)
 
 SafeRepresenter.add_representer(bytes,

--- a/tests/test_dump_load.py
+++ b/tests/test_dump_load.py
@@ -1,3 +1,6 @@
+import enum
+import sys
+
 import pytest
 import yaml
 
@@ -13,3 +16,11 @@ def test_load_no_loader():
 
 def test_load_safeloader():
     assert yaml.load("- foo\n", Loader=yaml.SafeLoader)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="StrEnum was added in Python 3.11")
+def test_StrEnum():
+    class TestEnum(enum.StrEnum):
+        TEST_VALUE = "test value"
+
+    assert yaml.load(yaml.dump(TestEnum.TEST_VALUE), Loader=yaml.SafeLoader) == TestEnum.TEST_VALUE


### PR DESCRIPTION
For instance, Python 3.11 introduced `enum.StrEnum`, which subclasses `str`, and should be used as such.