### PR TITLE
Fix AttributeError when node.id is accessed on non-Node objects

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -117,23 +117,23 @@ class BaseConstructor:
     def construct_scalar(self, node):
         if not isinstance(node, ScalarNode):
             raise ConstructorError(None, None,
-                    "expected a scalar node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a scalar node, but found %s" % getattr(node, 'id', type(node).__name__),
+                    getattr(node, 'start_mark', None))
         return node.value
 
     def construct_sequence(self, node, deep=False):
         if not isinstance(node, SequenceNode):
             raise ConstructorError(None, None,
-                    "expected a sequence node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a sequence node, but found %s" % getattr(node, 'id', type(node).__name__),
+                    getattr(node, 'start_mark', None))
         return [self.construct_object(child, deep=deep)
                 for child in node.value]
 
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,
-                    "expected a mapping node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a mapping node, but found %s" % getattr(node, 'id', type(node).__name__),
+                    getattr(node, 'start_mark', None))
         mapping = {}
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
@@ -147,8 +147,8 @@ class BaseConstructor:
     def construct_pairs(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,
-                    "expected a mapping node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a mapping node, but found %s" % getattr(node, 'id', type(node).__name__),
+                    getattr(node, 'start_mark', None))
         pairs = []
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
@@ -356,8 +356,8 @@ class SafeConstructor(BaseConstructor):
         omap = []
         yield omap
         if not isinstance(node, SequenceNode):
-            raise ConstructorError("while constructing an ordered map", node.start_mark,
-                    "expected a sequence, but found %s" % node.id, node.start_mark)
+            raise ConstructorError("while constructing an ordered map", getattr(node, 'start_mark', None),
+                    "expected a sequence, but found %s" % getattr(node, 'id', type(node).__name__), getattr(node, 'start_mark', None))
         for subnode in node.value:
             if not isinstance(subnode, MappingNode):
                 raise ConstructorError("while constructing an ordered map", node.start_mark,
@@ -377,8 +377,8 @@ class SafeConstructor(BaseConstructor):
         pairs = []
         yield pairs
         if not isinstance(node, SequenceNode):
-            raise ConstructorError("while constructing pairs", node.start_mark,
-                    "expected a sequence, but found %s" % node.id, node.start_mark)
+            raise ConstructorError("while constructing pairs", getattr(node, 'start_mark', None),
+                    "expected a sequence, but found %s" % getattr(node, 'id', type(node).__name__), getattr(node, 'start_mark', None))
         for subnode in node.value:
             if not isinstance(subnode, MappingNode):
                 raise ConstructorError("while constructing pairs", node.start_mark,


### PR DESCRIPTION
## Summary

Fixes #907 by safely accessing `node.id` and `node.start_mark` attributes in error handling code.

## Problem

When constructor methods like `construct_scalar()`, `construct_sequence()`, etc. receive a non-Node object (e.g., `None`, a type object, or any arbitrary Python object), the error handling code unconditionally accesses `node.id` and `node.start_mark`, which causes an `AttributeError` before the intended `ConstructorError` can be raised.

## Solution

Use `getattr()` to safely access these attributes:
- For `node.id`: fall back to `type(node).__name__` to still provide useful type information in the error message
- For `node.start_mark`: fall back to `None` since position information isn't available for non-Node objects

## Testing

Tested with the reproduction case from the issue:
```python
import yaml

class Null:
    pass

obj = yaml.loader.SafeLoader("")
ret = obj.construct_yaml_float(Null)
```

Before: `AttributeError: type object 'Null' has no attribute 'id'`
After: `ConstructorError: expected a scalar node, but found type`

Also verified that normal YAML parsing continues to work correctly.