### PR TITLE
Fix Reader.peek() IndexError when index exceeds buffer length

### DIFF
--- a/lib/yaml/reader.py
+++ b/lib/yaml/reader.py
@@ -89,7 +89,9 @@ class Reader(object):
             return self.buffer[self.pointer+index]
         except IndexError:
             self.update(index+1)
-            return self.buffer[self.pointer+index]
+            if self.pointer+index < len(self.buffer):
+                return self.buffer[self.pointer+index]
+            return '\0'
 
     def prefix(self, length=1):
         if self.pointer+length >= len(self.buffer):

--- a/tests/test_reader_peek.py
+++ b/tests/test_reader_peek.py
@@ -1,0 +1,56 @@
+import io
+
+import yaml
+import yaml.reader
+
+
+class TestReaderPeekBeyondBuffer:
+    """Tests for Reader.peek() when index exceeds available data.
+
+    Regression test for https://github.com/yaml/pyyaml/issues/904
+    """
+
+    def test_peek_beyond_end_returns_null(self):
+        """peek() past end of a string stream should return '\\0', not raise IndexError."""
+        reader = yaml.reader.Reader('abc')
+        assert reader.peek(4) == '\0'
+
+    def test_peek_at_null_terminator(self):
+        """peek() at the exact position of the null terminator should return '\\0'."""
+        reader = yaml.reader.Reader('abc')
+        # buffer is 'abc\0', so index 3 is the '\0'
+        assert reader.peek(3) == '\0'
+
+    def test_peek_far_beyond_end(self):
+        """peek() with a very large index should return '\\0'."""
+        reader = yaml.reader.Reader('abc')
+        assert reader.peek(100) == '\0'
+
+    def test_peek_within_range(self):
+        """peek() within range should still return the correct character."""
+        reader = yaml.reader.Reader('abc')
+        assert reader.peek(0) == 'a'
+        assert reader.peek(1) == 'b'
+        assert reader.peek(2) == 'c'
+
+    def test_peek_empty_string(self):
+        """peek() on an empty string should return '\\0'."""
+        reader = yaml.reader.Reader('')
+        assert reader.peek(0) == '\0'
+        assert reader.peek(1) == '\0'
+
+    def test_peek_beyond_end_bytes(self):
+        """peek() past end of a bytes stream should return '\\0'."""
+        reader = yaml.reader.Reader(b'abc')
+        assert reader.peek(4) == '\0'
+
+    def test_peek_beyond_end_file_stream(self):
+        """peek() past end of a file-like stream should return '\\0'."""
+        reader = yaml.reader.Reader(io.StringIO('abc'))
+        assert reader.peek(4) == '\0'
+
+    def test_loader_peek_beyond_end(self):
+        """Original reproducer from issue #904."""
+        obj = yaml.loader.Loader('abc')
+        ret = obj.peek(4)
+        assert ret == '\0'


### PR DESCRIPTION
Fixes #904

## Problem

`Reader.peek(index)` raises `IndexError` when the requested `index` exceeds the available data in the buffer. This happens because after calling `update()`, the buffer may still not have enough data (e.g., for string inputs where `raw_buffer` is `None` and `update()` returns immediately). The second buffer access then crashes.

```python
obj = yaml.loader.Loader('abc')
ret = obj.peek(4)  # IndexError: string index out of range
```

## Fix

Added a bounds check after `update()` in `peek()`. If the requested position is still past the end of the buffer, return `'\0'` instead of indexing into the buffer. This is consistent with how `'\0'` is used as the end-of-stream sentinel throughout the parser.

## Tests

Added tests covering:
- String, bytes, and file-like stream inputs
- Peek at exact end, one past end, and far past end
- Empty string input
- Normal in-range peek still works correctly

All 1280 existing legacy tests plus 3 existing modern tests continue to pass.