### PR TITLE
Fix IndexError in scan_tag() and check_key() on empty input

### DIFF
--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -716,7 +716,10 @@ class Scanner:
 
         # KEY(block context):   '?' (' '|'\n')
         else:
-            return self.peek(1) in '\0 \t\r\n\x85\u2028\u2029'
+            if self.pointer + 1 < len(self.buffer):
+                return self.peek(1) in '\0 \t\r\n\x85\u2028\u2029'
+            else:
+                return self.peek() == '\0'
 
     def check_value(self):
 
@@ -726,7 +729,10 @@ class Scanner:
 
         # VALUE(block context): ':' (' '|'\n')
         else:
-            return self.peek(1) in '\0 \t\r\n\x85\u2028\u2029'
+            if self.pointer + 1 < len(self.buffer):
+                return self.peek(1) in '\0 \t\r\n\x85\u2028\u2029'
+            else:
+                return self.peek() == '\0'
 
     def check_plain(self):
 
@@ -935,7 +941,10 @@ class Scanner:
     def scan_tag(self):
         # See the specification for details.
         start_mark = self.get_mark()
-        ch = self.peek(1)
+        if self.pointer + 1 < len(self.buffer):
+            ch = self.peek(1)
+        else:
+            ch = self.peek()
         if ch == '<':
             handle = None
             self.forward(2)
@@ -965,7 +974,10 @@ class Scanner:
                 handle = '!'
                 self.forward()
             suffix = self.scan_tag_uri('tag', start_mark)
-        ch = self.peek()
+        if self.pointer < len(self.buffer):
+            ch = self.peek()
+        else:
+            ch = '\0'
         if ch not in '\0 \r\n\x85\u2028\u2029':
             raise ScannerError("while scanning a tag", start_mark,
                     "expected ' ', but found %r" % ch, self.get_mark())


### PR DESCRIPTION
## Summary

Fixes #906 by adding buffer bounds checking before `peek(1)` calls in scanner methods.

When the input is an empty string or very short, calling `peek(1)` without validating buffer bounds causes `IndexError` because the buffer only contains the EOF marker (`\0`) at position 0, but `peek(1)` tries to access position 1.

## Changes

Added bounds checking in three methods in `lib/yaml/scanner.py`:

1. **`check_key()`** - Check if `pointer + 1 < len(buffer)` before `peek(1)`
2. **`check_value()`** - Check if `pointer + 1 < len(buffer)` before `peek(1)`
3. **`scan_tag()`** - Check buffer bounds before both `peek(1)` and `peek()` calls

When buffer bounds are insufficient, the code falls back to `peek()` which safely returns the EOF marker `\0`.

## Testing

Verified the fix with multiple test cases:

```python
# Previously raised IndexError, now works correctly
loader = yaml.loader.SafeLoader("")
loader.check_key()    # Returns True
loader.scan_tag()     # Returns TagToken
loader.check_value()  # Returns True
```

All existing tests pass:
- `tests/test_dump_load.py` - 3 tests passed
- `tests/legacy_tests/test_errors.py` - 189 tests passed

## Manual Test Results

```
1. check_key() with empty input: SUCCESS (no IndexError)
2. scan_tag() with empty input: SUCCESS (no IndexError)  
3. check_value() with empty input: SUCCESS (no IndexError)
4. Various YAML inputs parse correctly without IndexError
```

The fix ensures proper handling of edge cases while maintaining backward compatibility with all existing functionality.