### PR TITLE
Fix TypeError in prepare_tag_prefix on non-ASCII tag prefixes (Python 3)

### DIFF
--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -572,7 +572,7 @@ class Emitter:
                 start = end = end+1
                 data = ch.encode('utf-8')
                 for ch in data:
-                    chunks.append('%%%02X' % ord(ch))
+                    chunks.append('%%%02X' % ch)
         if start < end:
             chunks.append(prefix[start:end])
         return ''.join(chunks)


### PR DESCRIPTION
## Summary

`prepare_tag_prefix` crashes with a `TypeError` when given a tag prefix containing non-ASCII characters (e.g., Unicode) in Python 3.

## Problem

In Python 3, iterating over `bytes` yields `int` values, not single-byte `bytes` objects. The percent-encoding loop in `prepare_tag_prefix` calls `ord(ch)` on these integer values, which raises `TypeError`:

```python
data = ch.encode('utf-8')
for ch in data:
    chunks.append('%%%02X' % ord(ch))  # TypeError: ord() expected string of length 1, but int found
```

The sibling method `prepare_tag` (just below on line ~607) handles this correctly with `% ch` instead of `% ord(ch)`.

## Reproduction

```python
import yaml, io
from yaml.emitter import Emitter

stream = io.StringIO()
e = Emitter(stream)
e.prepare_tag_prefix('tag:ü,2002:')
# TypeError: ord() expected string of length 1, but int found
```

## Fix

Drop the redundant `ord()` call to match the working `prepare_tag` implementation:

```python
chunks.append('%%%02X' % ch)
```
