### PR TITLE
Fix off-by-one excluding U+10FFFF from valid Unicode range in emitter

### DIFF
--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -699,7 +699,7 @@ class Emitter:
             if not (ch == '\n' or '\x20' <= ch <= '\x7E'):
                 if (ch == '\x85' or '\xA0' <= ch <= '\uD7FF'
                         or '\uE000' <= ch <= '\uFFFD'
-                        or '\U00010000' <= ch < '\U0010ffff') and ch != '\uFEFF':
+                        or '\U00010000' <= ch <= '\U0010ffff') and ch != '\uFEFF':
                     unicode_characters = True
                     if not self.allow_unicode:
                         special_characters = True


### PR DESCRIPTION
## Summary

The emitter's `analyze_scalar` method has an off-by-one error that excludes U+10FFFF from the valid Unicode range, causing it to be treated as a "special character" and forcing double-quoted scalar style.

## Problem

The supplementary plane check uses strict less-than:

```python
or '\U00010000' <= ch < '\U0010ffff'
```

This excludes U+10FFFF, which is a valid Unicode code point per the YAML spec's `c-printable` production (YAML 1.1 section 4.1):

```
c-printable ::= ... | [#x10000-#x10FFFF]
```

Meanwhile, `reader.py` correctly uses an inclusive upper bound in its character validation regex:

```python
'\U00010000-\U0010ffff'
```

This creates an inconsistency: the reader accepts U+10FFFF, but the emitter treats it as special, unnecessarily forcing double-quoted style when the scalar could use plain, single-quoted, or block styles.

## Demonstration

```python
import yaml, io
from yaml.emitter import Emitter

e = Emitter(io.StringIO(), allow_unicode=True)

# U+10FFFE: correctly treated as valid unicode
a1 = e.analyze_scalar('\U0010fffe')
print(a1.allow_single_quoted)  # True

# U+10FFFF: incorrectly treated as special character
a2 = e.analyze_scalar('\U0010ffff')
print(a2.allow_single_quoted)  # False — should be True
```

## Fix

Change `<` to `<=` to include U+10FFFF in the valid range, matching both the YAML spec and the reader's validation.
