### PR TITLE
Fix ValueError/IndexError crash in SafeLoader for malformed numeric scalars (#898)

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -235,6 +235,14 @@ class SafeConstructor(BaseConstructor):
         return self.bool_values[value.lower()]
 
     def construct_yaml_int(self, node):
+        try:
+            return self._construct_yaml_int(node)
+        except (ValueError, IndexError) as exc:
+            raise ConstructorError(None, None,
+                    "could not convert value to int: %s" % exc,
+                    node.start_mark)
+
+    def _construct_yaml_int(self, node):
         value = self.construct_scalar(node)
         value = value.replace('_', '')
         sign = +1
@@ -268,6 +276,14 @@ class SafeConstructor(BaseConstructor):
     nan_value = -inf_value/inf_value   # Trying to make a quiet NaN (like C99).
 
     def construct_yaml_float(self, node):
+        try:
+            return self._construct_yaml_float(node)
+        except (ValueError, IndexError) as exc:
+            raise ConstructorError(None, None,
+                    "could not convert value to float: %s" % exc,
+                    node.start_mark)
+
+    def _construct_yaml_float(self, node):
         value = self.construct_scalar(node)
         value = value.replace('_', '').lower()
         sign = +1


### PR DESCRIPTION
## Summary

Fix uncaught `ValueError`/`IndexError` in `SafeLoader` when parsing malformed numeric scalars like `0x_`, `!!float +_`, and `!!float 1::3`.

## Root Cause

`construct_yaml_int` and `construct_yaml_float` strip underscores from the scalar value before parsing, but don't handle the case where stripping leaves an empty or invalid string:

| Input | After `replace('_', '')` | Failure |
|-------|--------------------------|---------|
| `0x_` | `0x` | `int('', 16)` → `ValueError` |
| `0b_` | `0b` | `int('', 2)` → `ValueError` |
| `!!float +_` | `+` → ``(empty after sign strip) | `value[0]` → `IndexError` |
| `!!float 1::3` | `1::3` | `float('')` (empty split part) → `ValueError` |

## Fix

Wrap the parsing logic in try/except to convert `ValueError` and `IndexError` into `ConstructorError`, which is the expected exception type for invalid YAML values. This matches the behavior of other constructors in PyYAML (e.g. `construct_yaml_binary`).

## Testing

```python
import yaml

# All now raise ConstructorError instead of ValueError/IndexError:
yaml.safe_load('0x_')        # ConstructorError ✓
yaml.safe_load('0b_')        # ConstructorError ✓  
yaml.safe_load('!!float +_') # ConstructorError ✓
yaml.safe_load('!!float 1::3') # ConstructorError ✓

# Normal values still work:
yaml.safe_load('42')        # 42 ✓
yaml.safe_load('0x1F')      # 31 ✓
yaml.safe_load('3.14')      # 3.14 ✓
```

Fixes #898