### PR TITLE
fix: handle edge cases in peek() and construct_scalar() error handling

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -117,8 +117,9 @@ class BaseConstructor:
     def construct_scalar(self, node):
         if not isinstance(node, ScalarNode):
             raise ConstructorError(None, None,
-                    "expected a scalar node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a scalar node, but found %s"
+                        % getattr(node, 'id', type(node).__name__),
+                    getattr(node, 'start_mark', None))
         return node.value
 
     def construct_sequence(self, node, deep=False):

--- a/lib/yaml/reader.py
+++ b/lib/yaml/reader.py
@@ -89,7 +89,10 @@ class Reader(object):
             return self.buffer[self.pointer+index]
         except IndexError:
             self.update(index+1)
-            return self.buffer[self.pointer+index]
+            try:
+                return self.buffer[self.pointer+index]
+            except IndexError:
+                return '\0'
 
     def prefix(self, length=1):
         if self.pointer+length >= len(self.buffer):


### PR DESCRIPTION
Fixes #906, fixes #907

## Changes

### Fix IndexError in `Reader.peek()` (#906)

When the input stream is empty or exhausted, `peek(index)` could raise an `IndexError` if the requested index exceeds the buffer length even after calling `update()`. This fix returns `'\0'` (the end-of-stream sentinel) instead of propagating the `IndexError`.

### Fix AttributeError in `construct_scalar()` error path (#907)

When `construct_scalar()` receives an object that is not a `Node` instance, the error-handling code accessed `node.id` and `node.start_mark` unconditionally, causing an `AttributeError`. This fix uses `getattr()` with safe fallbacks.

## Tests

All 1283 existing tests pass:
```
1283 passed, 1 warning in 2.29s
```