### PR TITLE
ci: add riscv64 wheel builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
           - { platform: manylinux1, arch: x86_64 }
           - { platform: manylinux2014, arch: x86_64 }
           - { platform: manylinux2014, arch: aarch64 }
-          - { platform: manylinux_2_28, arch: riscv64, omit: ${{ env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, omit: ${{ env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: musllinux_1_2, arch: x86_64 }
           - { platform: musllinux_1_2, arch: aarch64 }
@@ -162,12 +162,12 @@ jobs:
           - { platform: manylinux2014, arch: aarch64, spec: cp313, omit: ${{ env.skip_ci_redundant_jobs }} }
           - { platform: manylinux2014, arch: aarch64, spec: cp314 }
           - { platform: manylinux2014, arch: aarch64, spec: cp314t }
-          - { platform: manylinux_2_28, arch: riscv64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux_2_28, arch: riscv64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux_2_28, arch: riscv64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux_2_28, arch: riscv64, spec: cp313, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
-          - { platform: manylinux_2_28, arch: riscv64, spec: cp314, omit: ${{ env.skip_slow_jobs }} }
-          - { platform: manylinux_2_28, arch: riscv64, spec: cp314t, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp313, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp314, omit: ${{ env.skip_slow_jobs }} }
+          - { platform: manylinux_2_39, arch: riscv64, spec: cp314t, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp38, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
           - { platform: manylinux1, arch: x86_64 }
           - { platform: manylinux2014, arch: x86_64 }
           - { platform: manylinux2014, arch: aarch64 }
+          - { platform: manylinux_2_28, arch: riscv64, omit: ${{ env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: musllinux_1_2, arch: x86_64 }
           - { platform: musllinux_1_2, arch: aarch64 }
@@ -161,6 +162,12 @@ jobs:
           - { platform: manylinux2014, arch: aarch64, spec: cp313, omit: ${{ env.skip_ci_redundant_jobs }} }
           - { platform: manylinux2014, arch: aarch64, spec: cp314 }
           - { platform: manylinux2014, arch: aarch64, spec: cp314t }
+          - { platform: manylinux_2_28, arch: riscv64, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_28, arch: riscv64, spec: cp311, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_28, arch: riscv64, spec: cp312, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_28, arch: riscv64, spec: cp313, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
+          - { platform: manylinux_2_28, arch: riscv64, spec: cp314, omit: ${{ env.skip_slow_jobs }} }
+          - { platform: manylinux_2_28, arch: riscv64, spec: cp314t, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp38, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp39, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
           - { platform: manylinux2014, arch: s390x, spec: cp310, omit: ${{ env.skip_ci_redundant_jobs || env.skip_slow_jobs }} }
@@ -228,6 +235,7 @@ jobs:
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_S390X_IMAGE: ${{ matrix.manylinux_img || '' }}
+        CIBW_MANYLINUX_RISCV64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MUSLLINUX_X86_64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
         CIBW_MUSLLINUX_I686_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
         CIBW_MUSLLINUX_AARCH64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}


### PR DESCRIPTION
## Summary

Add `linux_riscv64` wheels to the CI workflow for both libyaml and pyyaml builds.

### Changes

- Add `{ platform: manylinux_2_28, arch: riscv64 }` to the libyaml build matrix
- Add `manylinux_2_28` riscv64 entries for CPython 3.10–3.14 (including free-threaded) to the pyyaml build matrix
- Add `CIBW_MANYLINUX_RISCV64_IMAGE` environment variable for cibuildwheel
- Marked as slow jobs (`omit: skip_slow_jobs`) to avoid running on every PR/push

### How it works

The existing workflow already handles riscv64 correctly:
- Runner selection: `ubuntu-24.04` (non-aarch64 fallback)
- QEMU setup: already triggers for `matrix.arch != 'x86_64' && matrix.arch != 'aarch64'`
- Docker image: `quay.io/pypa/manylinux_2_28_riscv64` exists and works

### Evidence

A tested riscv64 wheel is available in our community index:
https://gounthar.github.io/riscv64-python-wheels/simple/pyyaml/

Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz, 16 GB RAM).

### Context

- `manylinux_2_28_riscv64` is available in pypa/manylinux
- cibuildwheel supports riscv64 via QEMU
- Several packages already ship riscv64 wheels on PyPI (aiohttp, yarl, multidict, regex)
- RISC-V hardware is shipping (SiFive, SpacemiT K1/K3, Sophgo SG2044)

Closes #924

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).