### PR TITLE
Fix safe_load crash on malformed integer scalars (for example 0b_:)

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -236,31 +236,39 @@ class SafeConstructor(BaseConstructor):
 
     def construct_yaml_int(self, node):
         value = self.construct_scalar(node)
+        plain_value = value
         value = value.replace('_', '')
         sign = +1
         if value[0] == '-':
             sign = -1
         if value[0] in '+-':
             value = value[1:]
-        if value == '0':
-            return 0
-        elif value.startswith('0b'):
-            return sign*int(value[2:], 2)
-        elif value.startswith('0x'):
-            return sign*int(value[2:], 16)
-        elif value[0] == '0':
-            return sign*int(value, 8)
-        elif ':' in value:
-            digits = [int(part) for part in value.split(':')]
-            digits.reverse()
-            base = 1
-            value = 0
-            for digit in digits:
-                value += digit*base
-                base *= 60
-            return sign*value
-        else:
-            return sign*int(value)
+        try:
+            if value == '0':
+                return 0
+            elif value.startswith('0b'):
+                return sign*int(value[2:], 2)
+            elif value.startswith('0x'):
+                return sign*int(value[2:], 16)
+            elif value[0] == '0':
+                return sign*int(value, 8)
+            elif ':' in value:
+                digits = [int(part) for part in value.split(':')]
+                digits.reverse()
+                base = 1
+                value = 0
+                for digit in digits:
+                    value += digit*base
+                    base *= 60
+                return sign*value
+            else:
+                return sign*int(value)
+        except ValueError as exc:
+            raise ConstructorError(
+                "while constructing an integer", node.start_mark,
+                "found invalid integer value %r" % plain_value,
+                node.start_mark,
+            ) from exc
 
     inf_value = 1e300
     while inf_value != inf_value*inf_value:

--- a/tests/test_dump_load.py
+++ b/tests/test_dump_load.py
@@ -1,5 +1,6 @@
 import pytest
 import yaml
+from yaml.constructor import ConstructorError
 
 
 def test_dump():
@@ -13,3 +14,8 @@ def test_load_no_loader():
 
 def test_load_safeloader():
     assert yaml.load("- foo\n", Loader=yaml.SafeLoader)
+
+
+def test_safe_load_invalid_binary_integer_raises_constructor_error():
+    with pytest.raises(ConstructorError):
+        yaml.safe_load("0b_:")


### PR DESCRIPTION
This PR fixes an error-handling bug in integer construction: malformed integer-like YAML values such as 0b_: no longer leak a raw Python ValueError during safe_load. Instead, they now raise a proper YAML ConstructorError with clear context and location details, and a regression test was added to lock this behavior in.

Related Issue: #868 