### PR TITLE
Fix yaml.emit for percent-escaped tag prefixes

### DIFF
--- a/lib/yaml/emitter.py
+++ b/lib/yaml/emitter.py
@@ -571,8 +571,8 @@ class Emitter:
                     chunks.append(prefix[start:end])
                 start = end = end+1
                 data = ch.encode('utf-8')
-                for ch in data:
-                    chunks.append('%%%02X' % ord(ch))
+                for byte in data:
+                    chunks.append('%%%02X' % byte)
         if start < end:
             chunks.append(prefix[start:end])
         return ''.join(chunks)

--- a/tests/test_emit.py
+++ b/tests/test_emit.py
@@ -1,0 +1,12 @@
+import io
+
+import yaml
+
+
+def test_emit_tag_directive_with_percent_encoded_prefix_from_bytes():
+    events = list(yaml.parse(io.BytesIO(b"%TAG ! tag:%002:\n---")))
+
+    output = yaml.emit(events)
+
+    assert output == "%TAG ! tag:%002:\n---\n...\n"
+    assert list(yaml.parse(output))[1].tags == events[1].tags


### PR DESCRIPTION
Fixes #862.

## Summary
- stop calling `ord()` on `bytes` iteration results in `Emitter.prepare_tag_prefix()`
- add a regression test for emitting a `%TAG` directive parsed from bytes with a percent-escaped prefix

## Repro
```bash
PYTHONPATH=lib python3 - <<'PY'
import io
import yaml

text = io.BytesIO(b"%TAG ! tag:%002:\n---")
events = list(yaml.parse(text))
print(yaml.emit(events))
PY
```

## Validation
- `PYTHONPATH=lib python3 -m pytest tests/test_emit.py -q`
- `PYTHONPATH=lib python3 -m pytest tests/test_dump_load.py tests/test_emit.py -q`
- `PYTHONPATH=lib PYYAML_FORCE_LIBYAML=0 python3 -m pytest tests/legacy_tests/test_yaml.py -q -k emitter`