### PR TITLE
fix: wrap raw exceptions in construct_yaml_bool/int/float as ConstructorError

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -232,35 +232,45 @@ class SafeConstructor(BaseConstructor):
 
     def construct_yaml_bool(self, node):
         value = self.construct_scalar(node)
-        return self.bool_values[value.lower()]
+        try:
+            return self.bool_values[value.lower()]
+        except KeyError:
+            raise ConstructorError(None, None,
+                    "failed to construct a bool value from %r" % value,
+                    node.start_mark)
 
     def construct_yaml_int(self, node):
-        value = self.construct_scalar(node)
-        value = value.replace('_', '')
-        sign = +1
-        if value[0] == '-':
-            sign = -1
-        if value[0] in '+-':
-            value = value[1:]
-        if value == '0':
-            return 0
-        elif value.startswith('0b'):
-            return sign*int(value[2:], 2)
-        elif value.startswith('0x'):
-            return sign*int(value[2:], 16)
-        elif value[0] == '0':
-            return sign*int(value, 8)
-        elif ':' in value:
-            digits = [int(part) for part in value.split(':')]
-            digits.reverse()
-            base = 1
-            value = 0
-            for digit in digits:
-                value += digit*base
-                base *= 60
-            return sign*value
-        else:
-            return sign*int(value)
+        original = self.construct_scalar(node)
+        try:
+            value = original.replace('_', '')
+            sign = +1
+            if value[0] == '-':
+                sign = -1
+            if value[0] in '+-':
+                value = value[1:]
+            if value == '0':
+                return 0
+            elif value.startswith('0b'):
+                return sign*int(value[2:], 2)
+            elif value.startswith('0x'):
+                return sign*int(value[2:], 16)
+            elif value[0] == '0':
+                return sign*int(value, 8)
+            elif ':' in value:
+                digits = [int(part) for part in value.split(':')]
+                digits.reverse()
+                base = 1
+                result = 0
+                for digit in digits:
+                    result += digit*base
+                    base *= 60
+                return sign*result
+            else:
+                return sign*int(value)
+        except (ValueError, IndexError) as exc:
+            raise ConstructorError(None, None,
+                    "failed to construct an int value from %r: %s" % (original, exc),
+                    node.start_mark)
 
     inf_value = 1e300
     while inf_value != inf_value*inf_value:
@@ -268,28 +278,33 @@ class SafeConstructor(BaseConstructor):
     nan_value = -inf_value/inf_value   # Trying to make a quiet NaN (like C99).
 
     def construct_yaml_float(self, node):
-        value = self.construct_scalar(node)
-        value = value.replace('_', '').lower()
-        sign = +1
-        if value[0] == '-':
-            sign = -1
-        if value[0] in '+-':
-            value = value[1:]
-        if value == '.inf':
-            return sign*self.inf_value
-        elif value == '.nan':
-            return self.nan_value
-        elif ':' in value:
-            digits = [float(part) for part in value.split(':')]
-            digits.reverse()
-            base = 1
-            value = 0.0
-            for digit in digits:
-                value += digit*base
-                base *= 60
-            return sign*value
-        else:
-            return sign*float(value)
+        original = self.construct_scalar(node)
+        try:
+            value = original.replace('_', '').lower()
+            sign = +1
+            if value[0] == '-':
+                sign = -1
+            if value[0] in '+-':
+                value = value[1:]
+            if value == '.inf':
+                return sign*self.inf_value
+            elif value == '.nan':
+                return self.nan_value
+            elif ':' in value:
+                digits = [float(part) for part in value.split(':')]
+                digits.reverse()
+                base = 1
+                result = 0.0
+                for digit in digits:
+                    result += digit*base
+                    base *= 60
+                return sign*result
+            else:
+                return sign*float(value)
+        except (ValueError, IndexError) as exc:
+            raise ConstructorError(None, None,
+                    "failed to construct a float value from %r: %s" % (original, exc),
+                    node.start_mark)
 
     def construct_yaml_binary(self, node):
         try:

--- a/tests/test_invalid_tags.py
+++ b/tests/test_invalid_tags.py
@@ -1,0 +1,54 @@
+import pytest
+import yaml
+
+
+@pytest.mark.parametrize("document", [
+    '!!bool "maybe"',
+    '!!bool "yep"',
+    '!!bool "nope"',
+])
+def test_invalid_bool_tag_raises_yaml_error(document):
+    """!!bool with an unrecognised value must raise YAMLError, not raw KeyError."""
+    with pytest.raises(yaml.YAMLError):
+        yaml.safe_load(document)
+
+
+@pytest.mark.parametrize("document", [
+    '!!int "abc"',
+    '!!int ""',
+    '!!int "12abc"',
+])
+def test_invalid_int_tag_raises_yaml_error(document):
+    """!!int with a non-integer string must raise YAMLError, not raw ValueError/IndexError."""
+    with pytest.raises(yaml.YAMLError):
+        yaml.safe_load(document)
+
+
+@pytest.mark.parametrize("document", [
+    '!!float "abc"',
+    '!!float "not-a-float"',
+])
+def test_invalid_float_tag_raises_yaml_error(document):
+    """!!float with a non-numeric string must raise YAMLError, not raw ValueError."""
+    with pytest.raises(yaml.YAMLError):
+        yaml.safe_load(document)
+
+
+@pytest.mark.parametrize("document, expected", [
+    ("!!bool 'true'", True),
+    ("!!bool 'yes'", True),
+    ("!!bool 'false'", False),
+    ("!!bool 'no'", False),
+    ("!!int '42'", 42),
+    ("!!int '0xff'", 255),
+    ("!!int '0b1010'", 10),
+    ("!!float '3.14'", 3.14),
+    ("!!float '.inf'", float('inf')),
+])
+def test_valid_tags_still_work(document, expected):
+    """Valid scalar tags must still parse correctly after adding error handling."""
+    result = yaml.safe_load(document)
+    if expected == float('inf'):
+        assert result == expected
+    else:
+        assert result == expected


### PR DESCRIPTION
## Problem

`yaml.safe_load` raises raw `KeyError` / `ValueError` / `IndexError` when a document uses an explicit type tag with a value that doesn't match the expected format:

```python
yaml.safe_load('!!bool "maybe"')   # KeyError: 'maybe'
yaml.safe_load('!!int "abc"')      # ValueError: invalid literal for int()...
yaml.safe_load('!!int ""')         # IndexError: string index out of range
yaml.safe_load('!!float "abc"')    # ValueError: could not convert string to float
```

Applications that wrap `yaml.safe_load` in `except yaml.YAMLError` to handle untrusted input will let these raw exceptions propagate uncaught.

Closes #933

## Fix

Wrap the parsing logic in `construct_yaml_bool`, `construct_yaml_int`, and `construct_yaml_float` with `try/except` blocks that re-raise as `ConstructorError` (a `YAMLError` subclass) with a descriptive message and source location. `construct_yaml_binary` already followed this pattern.

## Testing

Added `tests/test_invalid_tags.py` with parametrised tests covering:
- all three error paths (bool / int / float)
- edge cases (`!!int ""`, `!!int "12abc"`)
- regression coverage ensuring valid tags still parse correctly

All 65 tests pass (48 existing + 17 new).