### PR TITLE
fix: safe_load coerces sequence keys to tuples for safe_dump round-trip (#938)

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -215,10 +215,43 @@ class SafeConstructor(BaseConstructor):
         if merge:
             node.value = merge + node.value
 
+    @staticmethod
+    def _make_hashable(key):
+        """Recursively convert lists to tuples so sequence keys are hashable.
+
+        ``safe_dump`` serialises tuple keys as YAML sequences
+        (``tag:yaml.org,2002:seq``), which ``construct_yaml_seq`` turns back
+        into lists.  A list cannot be used as a dict key, so we convert any
+        list (and nested lists) to tuples, restoring the original tuple key.
+        """
+        if isinstance(key, list):
+            return tuple(SafeConstructor._make_hashable(item) for item in key)
+        return key
+
     def construct_mapping(self, node, deep=False):
         if isinstance(node, MappingNode):
             self.flatten_mapping(node)
-        return super().construct_mapping(node, deep=deep)
+        mapping = {}
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(None, None,
+                    "expected a mapping node, but found %s" % node.id,
+                    node.start_mark)
+        for key_node, value_node in node.value:
+            # Keys must be fully constructed before use (deep=True ensures
+            # generator-based constructors like construct_yaml_seq are
+            # exhausted before we read the result).
+            key = self.construct_object(key_node, deep=True)
+            # safe_dump represents tuple keys as YAML sequences, which
+            # construct_object returns as lists.  Convert them back to
+            # tuples so the round-trip {(a, b): v} → YAML → dict works.
+            key = self._make_hashable(key)
+            if not isinstance(key, collections.abc.Hashable):
+                raise ConstructorError("while constructing a mapping",
+                        node.start_mark,
+                        "found unhashable key", key_node.start_mark)
+            value = self.construct_object(value_node, deep=deep)
+            mapping[key] = value
+        return mapping
 
     def construct_yaml_null(self, node):
         self.construct_scalar(node)
@@ -486,6 +519,14 @@ class FullConstructor(SafeConstructor):
     # 'extend' is blacklisted because it is used by
     # construct_python_object_apply to add `listitems` to a newly generate
     # python instance
+
+    def construct_mapping(self, node, deep=False):
+        # FullLoader does not coerce sequence keys to tuples — use the strict
+        # BaseConstructor behaviour (unhashable key → ConstructorError).
+        if isinstance(node, MappingNode):
+            self.flatten_mapping(node)
+        return BaseConstructor.construct_mapping(self, node, deep=deep)
+
     def get_state_keys_blacklist(self):
         return ['^extend$', '^__.*__$']
 

--- a/tests/test_dump_load.py
+++ b/tests/test_dump_load.py
@@ -1,5 +1,6 @@
 import pytest
 import yaml
+from yaml.constructor import ConstructorError
 
 
 def test_dump():
@@ -13,3 +14,32 @@ def test_load_no_loader():
 
 def test_load_safeloader():
     assert yaml.load("- foo\n", Loader=yaml.SafeLoader)
+
+
+# Tests for safe_dump / safe_load round-trip with tuple keys (issue #938).
+# safe_dump serialises tuple keys as YAML sequences; safe_load must convert
+# them back to tuples so that the round-trip restores the original dict.
+
+@pytest.mark.parametrize("original", [
+    {(1, 2): 0},
+    {(1,): "one-tuple"},
+    {(): "empty-tuple"},
+    {("a", "b"): "str-tuple"},
+    {((1, 2), (3, 4)): "nested"},
+    {"normal": 1, 42: True, (1, 2): "mixed"},
+])
+def test_safe_roundtrip_tuple_key(original):
+    """safe_load(safe_dump(d)) == d when d has tuple keys (GH-938)."""
+    assert yaml.safe_load(yaml.safe_dump(original)) == original
+
+
+def test_safe_load_sequence_key_becomes_tuple():
+    """A YAML sequence used as a mapping key is loaded as a tuple by SafeLoader."""
+    result = yaml.safe_load("? - 1\n  - 2\n: value\n")
+    assert result == {(1, 2): "value"}
+
+
+def test_full_load_sequence_key_still_errors():
+    """FullLoader must still reject unhashable (sequence) keys."""
+    with pytest.raises(ConstructorError, match="found unhashable key"):
+        yaml.full_load("? - foo\n  - bar\n: baz\n")


### PR DESCRIPTION
## Problem

`safe_dump({(1, 2): 0})` produces valid YAML with a sequence key (`? - 1\n  - 2\n: 0\n`), but `safe_load` on that YAML raises `ConstructorError: found unhashable key` because `construct_yaml_seq` returns a `list`, which cannot be used as a dict key.

```python
import yaml
s = yaml.safe_dump({(1, 2): 0})   # '? - 1\n  - 2\n: 0\n'
yaml.safe_load(s)                 # ConstructorError: found unhashable key
```

This breaks any round-trip through `safe_dump` / `safe_load` for dicts with tuple keys.

## Fix

Override `SafeConstructor.construct_mapping` to:

1. Construct each key node with `deep=True` so generator-based constructors (`construct_yaml_seq`) are fully exhausted before the result is read (without this the returned list is empty).
2. Recursively convert `list` keys to `tuple` via a new `_make_hashable` helper, restoring the original tuple.

`FullConstructor.construct_mapping` is explicitly restored to the strict `BaseConstructor` behaviour (sequence keys remain a `ConstructorError`) so the existing `unacceptable-key.loader-error` contract for `FullLoader` / `yaml.full_load` is unchanged.

## Tests

- Parametrised round-trip tests for flat, nested, and mixed tuple keys.
- Direct parse test: `? - 1\n  - 2\n: value\n` → `{(1, 2): "value"}`.
- Regression test confirming `FullLoader` still raises `ConstructorError` on sequence keys.

All 2624 tests pass (2616 pre-existing + 8 new).

Fixes #938