### PR TITLE
Wrap raw constructor exceptions in a `YAMLError` in `SafeConstructor`

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -101,9 +101,9 @@ class BaseConstructor:
                 data = constructor(self, node)
             else:
                 data = constructor(self, tag_suffix, node)
+        except YAMLError:
+            raise
         except Exception as e:
-            if isinstance(e, YAMLError):
-                raise e
             raise ConstructorError(None, node.start_mark, f"Error constructing {node.tag!r} with value {node.value!r}") from e
 
         if isinstance(data, types.GeneratorType):

--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -96,10 +96,16 @@ class BaseConstructor:
                     constructor = self.__class__.construct_sequence
                 elif isinstance(node, MappingNode):
                     constructor = self.__class__.construct_mapping
-        if tag_suffix is None:
-            data = constructor(self, node)
-        else:
-            data = constructor(self, tag_suffix, node)
+        try:
+            if tag_suffix is None:
+                data = constructor(self, node)
+            else:
+                data = constructor(self, tag_suffix, node)
+        except Exception as e:
+            if isinstance(e, YAMLError):
+                raise e
+            raise ConstructorError(None, node.start_mark, f"Error constructing {node.tag!r} with value {node.value!r}") from e
+
         if isinstance(data, types.GeneratorType):
             generator = data
             data = next(generator)

--- a/tests/test_dump_load.py
+++ b/tests/test_dump_load.py
@@ -13,3 +13,30 @@ def test_load_no_loader():
 
 def test_load_safeloader():
     assert yaml.load("- foo\n", Loader=yaml.SafeLoader)
+
+@pytest.mark.parametrize("yaml_input", [
+    '!!bool "maybe"',
+    '!!bool ""',
+    '!!bool "on"',
+    '!!int "astring"',
+    '!!int "0x"',
+    '!!int "0b"',
+    '!!int "1.5"',
+    '!!int "inf"',
+    '!!int ""',
+    '!!float "not-a-number"',
+    '!!float ""',
+    '!!float "0x10"',
+    '!!float "true"',
+    '!!binary "not-base64!!!"',
+    '!!binary "ñoño"',
+    '!!timestamp "not-a-date"',
+    '!!timestamp "2024-13-01"',
+    '!!timestamp "yesterday"',
+    '!!python/object:os.system {}',
+    '!!python/name:os.system',
+    '!!python/module:os',
+])
+def test_safeloader_explicit_tag_errors(yaml_input):
+    with pytest.raises(yaml.constructor.ConstructorError):
+        yaml.safe_load(yaml_input)


### PR DESCRIPTION
When passing an explicitly tagged value into `safe_load` like `yaml.safe_load('!!bool "maybe"')`, pyyaml now raises a `ConstructorError` (a subclass of `YAMLError`) so that it can be caught in a `try: ... except YAMLError` structure.

Differs from #940 by moving where the exception is raised up the stack. Also includes tests.

Fixes #933