### PR TITLE
fix: use type().__name__ in constructor error messages to avoid AttributeError (#907)

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -117,23 +117,23 @@ class BaseConstructor:
     def construct_scalar(self, node):
         if not isinstance(node, ScalarNode):
             raise ConstructorError(None, None,
-                    "expected a scalar node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a scalar node, but found %s" % type(node).__name__,
+                    getattr(node, 'start_mark', None))
         return node.value
 
     def construct_sequence(self, node, deep=False):
         if not isinstance(node, SequenceNode):
             raise ConstructorError(None, None,
-                    "expected a sequence node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a sequence node, but found %s" % type(node).__name__,
+                    getattr(node, 'start_mark', None))
         return [self.construct_object(child, deep=deep)
                 for child in node.value]
 
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,
-                    "expected a mapping node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a mapping node, but found %s" % type(node).__name__,
+                    getattr(node, 'start_mark', None))
         mapping = {}
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
@@ -147,8 +147,8 @@ class BaseConstructor:
     def construct_pairs(self, node, deep=False):
         if not isinstance(node, MappingNode):
             raise ConstructorError(None, None,
-                    "expected a mapping node, but found %s" % node.id,
-                    node.start_mark)
+                    "expected a mapping node, but found %s" % type(node).__name__,
+                    getattr(node, 'start_mark', None))
         pairs = []
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
@@ -197,7 +197,7 @@ class SafeConstructor(BaseConstructor):
                             raise ConstructorError("while constructing a mapping",
                                     node.start_mark,
                                     "expected a mapping for merging, but found %s"
-                                    % subnode.id, subnode.start_mark)
+                                    % type(subnode).__name__, getattr(subnode, 'start_mark', None))
                         self.flatten_mapping(subnode)
                         for pair in subnode.value:
                             if (key_id := id(pair[0].value)) not in merge_key_ids:
@@ -206,7 +206,7 @@ class SafeConstructor(BaseConstructor):
                 else:
                     raise ConstructorError("while constructing a mapping", node.start_mark,
                             "expected a mapping or list of mappings for merging, but found %s"
-                            % value_node.id, value_node.start_mark)
+                            % type(value_node).__name__, getattr(value_node, 'start_mark', None))
             elif key_node.tag == 'tag:yaml.org,2002:value':
                 key_node.tag = 'tag:yaml.org,2002:str'
                 index += 1
@@ -360,12 +360,12 @@ class SafeConstructor(BaseConstructor):
         yield omap
         if not isinstance(node, SequenceNode):
             raise ConstructorError("while constructing an ordered map", node.start_mark,
-                    "expected a sequence, but found %s" % node.id, node.start_mark)
+                    "expected a sequence, but found %s" % type(node).__name__, getattr(node, 'start_mark', None))
         for subnode in node.value:
             if not isinstance(subnode, MappingNode):
                 raise ConstructorError("while constructing an ordered map", node.start_mark,
-                        "expected a mapping of length 1, but found %s" % subnode.id,
-                        subnode.start_mark)
+                        "expected a mapping of length 1, but found %s" % type(subnode).__name__,
+                        getattr(subnode, 'start_mark', None))
             if len(subnode.value) != 1:
                 raise ConstructorError("while constructing an ordered map", node.start_mark,
                         "expected a single mapping item, but found %d items" % len(subnode.value),
@@ -381,12 +381,12 @@ class SafeConstructor(BaseConstructor):
         yield pairs
         if not isinstance(node, SequenceNode):
             raise ConstructorError("while constructing pairs", node.start_mark,
-                    "expected a sequence, but found %s" % node.id, node.start_mark)
+                    "expected a sequence, but found %s" % type(node).__name__, getattr(node, 'start_mark', None))
         for subnode in node.value:
             if not isinstance(subnode, MappingNode):
                 raise ConstructorError("while constructing pairs", node.start_mark,
-                        "expected a mapping of length 1, but found %s" % subnode.id,
-                        subnode.start_mark)
+                        "expected a mapping of length 1, but found %s" % type(subnode).__name__,
+                        getattr(subnode, 'start_mark', None))
             if len(subnode.value) != 1:
                 raise ConstructorError("while constructing pairs", node.start_mark,
                         "expected a single mapping item, but found %d items" % len(subnode.value),

--- a/tests/test_issue_907.py
+++ b/tests/test_issue_907.py
@@ -1,0 +1,67 @@
+"""Tests for issue #907: ConstructorError raises AttributeError when
+construct_* methods receive non-Node objects.
+
+The bug: construct_scalar, construct_sequence, construct_mapping, and
+construct_pairs all access node.id and node.start_mark on the error path
+when the object is not a Node subclass. If a non-Node (e.g. list, dict,
+int) is passed, this raises AttributeError instead of ConstructorError.
+"""
+
+import pytest
+import yaml
+from yaml.constructor import ConstructorError
+
+
+class TestConstructorTypeCheck:
+    """construct_* methods should raise ConstructorError (not AttributeError)
+    when called with non-Node objects."""
+
+    def test_construct_scalar_non_node(self):
+        """construct_scalar with a non-Node should raise ConstructorError."""
+        from yaml.nodes import ScalarNode
+        loader = yaml.SafeLoader("")
+        with pytest.raises(ConstructorError, match="expected a scalar node"):
+            loader.construct_scalar([1, 2, 3])
+
+    def test_construct_sequence_non_node(self):
+        """construct_sequence with a non-Node should raise ConstructorError."""
+        loader = yaml.SafeLoader("")
+        with pytest.raises(ConstructorError, match="expected a sequence node"):
+            loader.construct_sequence("not a node")
+
+    def test_construct_mapping_non_node(self):
+        """construct_mapping with a non-Node should raise ConstructorError."""
+        loader = yaml.SafeLoader("")
+        with pytest.raises(ConstructorError, match="expected a mapping node"):
+            loader.construct_mapping(42)
+
+    def test_construct_pairs_non_node(self):
+        """construct_pairs with a non-Node should raise ConstructorError."""
+        loader = yaml.SafeLoader("")
+        with pytest.raises(ConstructorError, match="expected a mapping node"):
+            loader.construct_pairs(None)
+
+
+class TestSafeLoaderEdgeCases:
+    """Ensure safe_load still works correctly with various inputs after
+    the constructor type-check fix."""
+
+    def test_safe_load_normal(self):
+        result = yaml.safe_load("a: 1\nb: 2")
+        assert result == {"a": 1, "b": 2}
+
+    def test_safe_load_list(self):
+        result = yaml.safe_load("- 1\n- 2\n- 3")
+        assert result == [1, 2, 3]
+
+    def test_safe_load_scalar(self):
+        result = yaml.safe_load("hello")
+        assert result == "hello"
+
+    def test_safe_load_empty(self):
+        result = yaml.safe_load("")
+        assert result is None
+
+    def test_safe_load_nested(self):
+        result = yaml.safe_load("outer:\n  inner:\n    key: value")
+        assert result == {"outer": {"inner": {"key": "value"}}}


### PR DESCRIPTION
## Summary

Fixes #907 — ConstructorError raised AttributeError when construct_scalar, construct_sequence, construct_mapping, or construct_pairs received non-Node objects.

### The Bug

All four construct_* methods access 
ode.id and 
ode.start_mark in their type-check error paths. When a non-Node object (e.g. list, dict, int, None) is passed, this raises AttributeError instead of the intended ConstructorError:

`
AttributeError: 'list' object has no attribute 'id'
`

### The Fix

Replace 
ode.id with 	ype(node).__name__ and 
ode.start_mark with getattr(node, 'start_mark', None) in all 10 error handlers across BaseConstructor and SafeConstructor:

- construct_scalar — 1 handler
- construct_sequence — 1 handler  
- construct_mapping — 1 handler
- construct_pairs — 1 handler
- latten_mapping — 2 handlers (sequence merge subnode check, non-mapping value check)
- construct_yaml_omap — 2 handlers (sequence check, mapping subnode check)
- construct_yaml_pairs — 2 handlers (sequence check, mapping subnode check)

### Testing

Added 	ests/test_issue_907.py with 9 tests:
- 4 tests verify ConstructorError is raised (not AttributeError) for each construct_* method
- 5 tests verify normal safe_load behavior is unaffected

All existing tests continue to pass.