### PR TITLE
Fix bare except clauses in test_multi_constructor.py

### DIFF
--- a/tests/legacy_tests/test_multi_constructor.py
+++ b/tests/legacy_tests/test_multi_constructor.py
@@ -14,10 +14,10 @@ def myconstructor2(constructor, tag, node):
     string = ''
     try:
         i = tag.index('!') + 1
-    except:
+    except ValueError:
         try:
             i = tag.rindex(':') + 1
-        except:
+        except ValueError:
             pass
     if i >= 0:
         tag = tag[i:]


### PR DESCRIPTION
Replace bare `except:` clauses with `except ValueError:` in `tests/legacy_tests/test_multi_constructor.py`.

Bare `except:` catches `BaseException` (including `SystemExit` and `KeyboardInterrupt`), which can mask serious errors. The `str.index()` and `str.rindex()` methods raise `ValueError` on failure, so that is the correct specific exception to catch here.