### PR TITLE
Fix for YAML 1.1 multi-document directives

### DIFF
--- a/lib/yaml/parser.py
+++ b/lib/yaml/parser.py
@@ -215,27 +215,28 @@ class Parser:
             return self.parse_block_node()
 
     def process_directives(self):
-        self.yaml_version = None
-        self.tag_handles = {}
-        while self.check_token(DirectiveToken):
-            token = self.get_token()
-            if token.name == 'YAML':
-                if self.yaml_version is not None:
-                    raise ParserError(None, None,
-                            "found duplicate YAML directive", token.start_mark)
-                major, minor = token.value
-                if major != 1:
-                    raise ParserError(None, None,
-                            "found incompatible YAML document (version 1.* is required)",
-                            token.start_mark)
-                self.yaml_version = token.value
-            elif token.name == 'TAG':
-                handle, prefix = token.value
-                if handle in self.tag_handles:
-                    raise ParserError(None, None,
-                            "duplicate tag handle %r" % handle,
-                            token.start_mark)
-                self.tag_handles[handle] = prefix
+        if self.check_token(DirectiveToken):
+            self.yaml_version = None
+            self.tag_handles = {}
+            while self.check_token(DirectiveToken):
+                token = self.get_token()
+                if token.name == 'YAML':
+                    if self.yaml_version is not None:
+                        raise ParserError(None, None,
+                                "found duplicate YAML directive", token.start_mark)
+                    major, minor = token.value
+                    if major != 1:
+                        raise ParserError(None, None,
+                                "found incompatible YAML document (version 1.* is required)",
+                                token.start_mark)
+                    self.yaml_version = token.value
+                elif token.name == 'TAG':
+                    handle, prefix = token.value
+                    if handle in self.tag_handles:
+                        raise ParserError(None, None,
+                                "duplicate tag handle %r" % handle,
+                                token.start_mark)
+                    self.tag_handles[handle] = prefix
         if self.tag_handles:
             value = self.yaml_version, self.tag_handles.copy()
         else:


### PR DESCRIPTION
fixes #299

The [YAML 1.1](http://yaml.org/spec/1.1/#l-first-document) specification says:
> If the document specifies no directives, it is parsed using the same settings as the previous document. If the document does specify any directives, all directives of previous documents, if any, are ignored.

This is a simple update so that if no directives are present in the current document, then the previously declared directives are used instead.