### PR TITLE
fix: IndexError in scan_tag() and check_key() on empty input

### DIFF
--- a/lib/yaml/reader.py
+++ b/lib/yaml/reader.py
@@ -89,6 +89,9 @@ class Reader(object):
             return self.buffer[self.pointer+index]
         except IndexError:
             self.update(index+1)
+            # If after update we still don't have enough data, return '\0' (EOF)
+            if self.pointer + index >= len(self.buffer):
+                return '\0'
             return self.buffer[self.pointer+index]
 
     def prefix(self, length=1):


### PR DESCRIPTION
Fixes #906

### Root cause

On empty input, `scanner.peek(index)` raises `IndexError` when the buffer does not contain enough characters, instead of signalling end of input.

### Summary

Return the EOF marker when the buffer still lacks enough data after `update()`, so the scanner terminates cleanly on empty input. The change is minimal and localized to `lib/yaml/reader.py`.

### Verification

- `pytest -q --tb=short --no-header`
- Target test passes after the fix
- Full regression suite passes
