### PR TITLE
fix: IndexError in scan_tag() and check_key() on empty input

### DIFF
--- a/lib/yaml/scanner.py
+++ b/lib/yaml/scanner.py
@@ -711,6 +711,8 @@ class Scanner:
     def check_key(self):
 
         # KEY(flow context):    '?'
+        if self.peek() == '\0':
+            return False
         if self.flow_level:
             return True
 
@@ -935,6 +937,9 @@ class Scanner:
     def scan_tag(self):
         # See the specification for details.
         start_mark = self.get_mark()
+        if self.peek() == '\0':
+            raise ScannerError("while scanning a tag", start_mark,
+                    "unexpected end of stream", self.get_mark())
         ch = self.peek(1)
         if ch == '<':
             handle = None


### PR DESCRIPTION
Fixes #906

### Root cause

See the linked issue #906 for the failure report and reproduction.

### Summary

See the diff. The change is minimal and localized.

### Changed files

- `lib/yaml/scanner.py`

### Verification

- `pytest -q --tb=short --no-header`
- Target test passes after the fix
- Full regression suite passes

Low risk. Changes are localized and covered by tests.
