### PR TITLE
fix: Reader.peek(index) throws IndexError when the stream ends, instea

### DIFF
--- a/lib/yaml/reader.py
+++ b/lib/yaml/reader.py
@@ -89,7 +89,10 @@ class Reader(object):
             return self.buffer[self.pointer+index]
         except IndexError:
             self.update(index+1)
-            return self.buffer[self.pointer+index]
+            try:
+                return self.buffer[self.pointer+index]
+            except IndexError:
+                return '\0'
 
     def prefix(self, length=1):
         if self.pointer+length >= len(self.buffer):


### PR DESCRIPTION
Fixes #904

### Root cause

See the linked issue #904 for the failure report and reproduction.

### Summary

See the diff. The change is minimal and localized.

### Changed files

- `lib/yaml/reader.py`

### Verification

- `pytest -q --tb=short --no-header`
- Target test passes after the fix
- Full regression suite passes

Low risk. Changes are localized and covered by tests.
