### PR TITLE
fix: "AttributeError: cython_sources" with Cython 3.0.0a10

### DIFF
--- a/packaging/_pyyaml_pep517.py
+++ b/packaging/_pyyaml_pep517.py
@@ -1,6 +1,22 @@
 import inspect
 
 
+def _patch_cython_build_ext():
+    try:
+        from Cython.Build.Dependencies import cythonize
+        from Cython.Distutils import build_ext
+    except ImportError:
+        return
+
+    if hasattr(build_ext, 'cython_sources'):
+        return
+
+    def cython_sources(self, sources, extension):
+        return cythonize([extension])[0].sources
+
+    build_ext.cython_sources = cython_sources
+
+
 def _bridge_build_meta():
     import functools
     import sys
@@ -47,5 +63,5 @@ def _expose_config_settings(real_method, *args, **kwargs):
         return real_method(*args, **kwargs)
 
 
+_patch_cython_build_ext()
 _bridge_build_meta()
-


### PR DESCRIPTION
Fixes #601

### Root cause

See the linked issue #601 for the failure report and reproduction.

### Summary

See the diff. The change is minimal and localized.

### Changed files

- `packaging/_pyyaml_pep517.py`

### Verification

- `pytest -q --tb=long --no-header`
- Target test passes after the fix
- Full regression suite passes

Low risk. Changes are localized and covered by tests.
