### PR TITLE
Fix merge key precedence regression from PR #937

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -188,11 +188,11 @@ class SafeConstructor(BaseConstructor):
                 if isinstance(value_node, MappingNode):
                     self.flatten_mapping(value_node)
                     for pair in value_node.value:
-                        if (key_id := id(pair[0].value)) not in merge_key_ids:
+                        if (key_id := id(pair[0])) not in merge_key_ids:
                             merge_key_ids.add(key_id)
                             merge.append(pair)
                 elif isinstance(value_node, SequenceNode):
-                    for subnode in value_node.value:
+                    for subnode in reversed(value_node.value):
                         if not isinstance(subnode, MappingNode):
                             raise ConstructorError("while constructing a mapping",
                                     node.start_mark,
@@ -200,7 +200,7 @@ class SafeConstructor(BaseConstructor):
                                     % subnode.id, subnode.start_mark)
                         self.flatten_mapping(subnode)
                         for pair in subnode.value:
-                            if (key_id := id(pair[0].value)) not in merge_key_ids:
+                            if (key_id := id(pair[0])) not in merge_key_ids:
                                 merge_key_ids.add(key_id)
                                 merge.append(pair)
                 else:


### PR DESCRIPTION
### Summary

This PR fixes a regression in merge key precedence behavior introduced by PR #937. After that PR, merge keys with multi-character names incorrectly use last-wins precedence instead of the spec-compliant first-wins behavior.

**Fixes:** #953  
**Related:** #937, #897, #610

### Problem

PR #937 successfully fixed the merge-key DoS vulnerability, but made two changes to `flatten_mapping()` that affected precedence:

1. Removed `submerge.reverse()` 
2. Changed deduplication to use `id(pair[0].value)` (key's value identity)

This causes merge precedence to depend on key length and Python's string interning:
- Multi-character keys: Different string objects → different `id()` → no deduplication → last-wins
- Single-character keys: CPython interns them → same `id()` → deduplication → first-wins (accidental)

### YAML Specification

From [yaml.org/type/merge.html](https://yaml.org/type/merge.html):
> "Keys in mapping nodes **earlier in the sequence** override keys specified in **later mapping nodes**."

The specification requires first-wins behavior.

### The Fix

This PR restores spec-compliant behavior by:

1. Using node identity `id(pair[0])` instead of value identity `id(pair[0].value)` for deduplication
2. Processing sequence nodes in reverse order: `for subnode in reversed(value_node.value)`

This maintains O(N) complexity from #937 while restoring correct precedence semantics.

### Testing

**Before this fix (main branch):**
```python
import yaml
doc = """
a: &a {kk: 1}
b: &b {kk: 2}
c: &c {kk: 3}
result:
  <<: [*a, *b, *c]
"""
print(yaml.safe_load(doc)['result']['kk'])
# Output: 3 (last-wins - incorrect)
```

**After this fix:**
```python
# Output: 1 (first-wins - correct per spec)
```

### Verification

✅ All existing tests pass  
✅ Restores 6.0.3 behavior for multi-character keys  
✅ Preserves O(N) DoS protection from #937  
✅ Spec-compliant per yaml.org/type/merge.html

### Backwards Compatibility

- **Released versions (6.0.3 and earlier):** No impact - already have correct behavior
- **Main branch:** Fixes regression before next release
- **Breaking changes:** None - restores spec-compliant behavior
