### PR TITLE
Guard the C dumper against reentrant calls into the emitter

### DIFF
--- a/lib/yaml/cyaml.py
+++ b/lib/yaml/cyaml.py
@@ -48,7 +48,48 @@ class CLoader(CParser, Constructor, Resolver):
         Constructor.__init__(self)
         Resolver.__init__(self)
 
-class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
+class _CEmitterGuard:
+    """Blocks reentrant calls into the C emitter.
+
+    A stream write() callback can end up calling close() (or open()/
+    serialize()) on the same dumper while an earlier call into the C
+    emitter for that dumper is still on the stack. The emitter's
+    internal state isn't designed to be torn down and rebuilt mid-call,
+    and letting that happen corrupts it badly enough to crash the
+    process during cleanup. Raise instead of ever making that call.
+    """
+
+    def open(self):
+        if getattr(self, '_cyaml_active', False):
+            raise RuntimeError(
+                'cannot call open() while this dumper is already emitting')
+        self._cyaml_active = True
+        try:
+            return super().open()
+        finally:
+            self._cyaml_active = False
+
+    def serialize(self, node):
+        if getattr(self, '_cyaml_active', False):
+            raise RuntimeError(
+                'cannot call serialize() while this dumper is already emitting')
+        self._cyaml_active = True
+        try:
+            return super().serialize(node)
+        finally:
+            self._cyaml_active = False
+
+    def close(self):
+        if getattr(self, '_cyaml_active', False):
+            raise RuntimeError(
+                'cannot call close() while this dumper is already emitting')
+        self._cyaml_active = True
+        try:
+            return super().close()
+        finally:
+            self._cyaml_active = False
+
+class CBaseDumper(_CEmitterGuard, CEmitter, BaseRepresenter, BaseResolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=False,
@@ -65,7 +106,7 @@ class CBaseDumper(CEmitter, BaseRepresenter, BaseResolver):
                 default_flow_style=default_flow_style, sort_keys=sort_keys)
         Resolver.__init__(self)
 
-class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
+class CSafeDumper(_CEmitterGuard, CEmitter, SafeRepresenter, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=False,
@@ -82,7 +123,7 @@ class CSafeDumper(CEmitter, SafeRepresenter, Resolver):
                 default_flow_style=default_flow_style, sort_keys=sort_keys)
         Resolver.__init__(self)
 
-class CDumper(CEmitter, Serializer, Representer, Resolver):
+class CDumper(_CEmitterGuard, CEmitter, Serializer, Representer, Resolver):
 
     def __init__(self, stream,
             default_style=None, default_flow_style=False,

--- a/tests/test_dump_load.py
+++ b/tests/test_dump_load.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 import pytest
 import yaml
 
@@ -13,3 +17,45 @@ def test_load_no_loader():
 
 def test_load_safeloader():
     assert yaml.load("- foo\n", Loader=yaml.SafeLoader)
+
+
+@pytest.mark.skipif(not yaml.__with_libyaml__,
+                     reason="requires the libyaml C extension")
+def test_cdumper_reentrant_close_from_write_raises_instead_of_crashing():
+    # A stream write() callback that calls close() on the dumper it's
+    # writing for used to corrupt the C emitter's internal state badly
+    # enough to abort the process during cleanup, instead of raising.
+    # Runs in a subprocess so a regression here crashes that process,
+    # not this test run.
+    script = textwrap.dedent("""
+        import yaml
+
+        class ReentrantStream:
+            def __init__(self):
+                self.dumper = None
+                self.called = False
+
+            def write(self, value):
+                if not self.called:
+                    self.called = True
+                    self.dumper.close()
+
+        class ReentrantDumper(yaml.CDumper):
+            def __init__(self, stream, *args, **kwargs):
+                super().__init__(stream, *args, **kwargs)
+                stream.dumper = self
+
+        try:
+            yaml.dump("value", ReentrantStream(), Dumper=ReentrantDumper)
+        except RuntimeError:
+            print("raised-cleanly")
+        else:
+            print("no-error-raised")
+    """)
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        capture_output=True, text=True, timeout=10)
+    assert result.returncode == 0, (
+        f"subprocess terminated abnormally (returncode={result.returncode}): "
+        f"{result.stderr}")
+    assert result.stdout.strip() == "raised-cleanly"


### PR DESCRIPTION
Fixes #956.

A stream `write()` callback that calls `close()` on the dumper it's writing for reaches straight into the C emitter while an earlier `open()`/`serialize()` call for the same dumper is still on the stack. The emitter isn't built to have its state torn down and rebuilt mid-call, and letting that happen corrupts it badly enough that the process aborts during cleanup instead of raising a normal Python exception.

On this machine, the reported repro doesn't reproduce as a plain segfault but as a SIGABRT (exit code 134) after an `EmitterError` is printed, which points at the same underlying issue: the reentrant `close()` corrupts the emitter's state, so the outer call resumes into a broken state machine and something in cleanup aborts.

`CBaseDumper`, `CSafeDumper` and `CDumper` now go through a small guard that tracks whether a call into `open()`/`serialize()`/`close()` is already in progress for that instance, and raises `RuntimeError` immediately on a reentrant call rather than ever reaching the C code again.

Added a regression test that reproduces the exact reentrant-close scenario from a stream `write()` callback. It runs in a subprocess so a regression crashes that subprocess rather than the test run itself, and asserts a clean `RuntimeError` instead of an abnormal termination. Confirmed it fails (subprocess terminates with returncode -6) against the unpatched code and passes with the fix.

Ran the full test suite (both the modern pytest tests and the legacy `test_all.py`, which exercises the C extension) locally against a build linked to libyaml — 2606 tests pass, no failures.