### PR TITLE
Wrap int/float scalar construction in ConstructorError

### DIFF
--- a/lib/yaml/constructor.py
+++ b/lib/yaml/constructor.py
@@ -245,25 +245,30 @@ class SafeConstructor(BaseConstructor):
             sign = -1
         if value[0] in '+-':
             value = value[1:]
-        if value == '0':
-            return 0
-        elif value.startswith('0b'):
-            return sign*int(value[2:], 2)
-        elif value.startswith('0x'):
-            return sign*int(value[2:], 16)
-        elif value[0] == '0':
-            return sign*int(value, 8)
-        elif ':' in value:
-            digits = [int(part) for part in value.split(':')]
-            digits.reverse()
-            base = 1
-            value = 0
-            for digit in digits:
-                value += digit*base
-                base *= 60
-            return sign*value
-        else:
-            return sign*int(value)
+        try:
+            if value == '0':
+                return 0
+            elif value.startswith('0b'):
+                return sign*int(value[2:], 2)
+            elif value.startswith('0x'):
+                return sign*int(value[2:], 16)
+            elif value[0] == '0':
+                return sign*int(value, 8)
+            elif ':' in value:
+                digits = [int(part) for part in value.split(':')]
+                digits.reverse()
+                base = 1
+                value = 0
+                for digit in digits:
+                    value += digit*base
+                    base *= 60
+                return sign*value
+            else:
+                return sign*int(value)
+        except ValueError:
+            raise ConstructorError(None, None,
+                    "failed to construct int from scalar %r" % (node.value,),
+                    node.start_mark)
 
     inf_value = 1e300
     while inf_value != inf_value*inf_value:
@@ -282,17 +287,22 @@ class SafeConstructor(BaseConstructor):
             return sign*self.inf_value
         elif value == '.nan':
             return self.nan_value
-        elif ':' in value:
-            digits = [float(part) for part in value.split(':')]
-            digits.reverse()
-            base = 1
-            value = 0.0
-            for digit in digits:
-                value += digit*base
-                base *= 60
-            return sign*value
-        else:
-            return sign*float(value)
+        try:
+            if ':' in value:
+                digits = [float(part) for part in value.split(':')]
+                digits.reverse()
+                base = 1
+                value = 0.0
+                for digit in digits:
+                    value += digit*base
+                    base *= 60
+                return sign*value
+            else:
+                return sign*float(value)
+        except ValueError:
+            raise ConstructorError(None, None,
+                    "failed to construct float from scalar %r" % (node.value,),
+                    node.start_mark)
 
     def construct_yaml_binary(self, node):
         try:

--- a/tests/test_malformed_numeric_scalars.py
+++ b/tests/test_malformed_numeric_scalars.py
@@ -1,0 +1,41 @@
+import pytest
+import yaml
+
+
+@pytest.mark.parametrize("source", [
+    "0x_",
+    "0b_",
+    "!!int 1::3",
+])
+def test_malformed_int_scalar_raises_yaml_error(source):
+    with pytest.raises(yaml.YAMLError):
+        yaml.safe_load(source)
+
+
+@pytest.mark.parametrize("source", [
+    "!!float +_",
+    "!!float 1::3",
+])
+def test_malformed_float_scalar_raises_yaml_error(source):
+    with pytest.raises(yaml.YAMLError):
+        yaml.safe_load(source)
+
+
+@pytest.mark.parametrize("source,expected", [
+    ("0x1A", 26),
+    ("0b101", 5),
+    ("017", 15),
+    ("1_000", 1000),
+    ("0_", 0),
+    ("!!int 1:30", 90),
+])
+def test_valid_int_scalar_still_parses(source, expected):
+    assert yaml.safe_load(source) == expected
+
+
+@pytest.mark.parametrize("source,expected", [
+    ("!!float 1.5", 1.5),
+    ("!!float 1:30:00", 5400.0),
+])
+def test_valid_float_scalar_still_parses(source, expected):
+    assert yaml.safe_load(source) == expected


### PR DESCRIPTION
Issue #898 shows three ways to crash SafeLoader with a plain ValueError: \`0x_\`, \`!!float +_\`, and \`!!float 1::3\`.

The implicit resolver's int regex allows a digit group that's entirely underscores (\`0b[0-1_]+\`, \`0x[0-9a-fA-F_]+\`, and so on never require at least one real digit), so something like \`0x_\` gets tagged as an int and handed to \`construct_yaml_int\`, which strips the underscores and calls \`int('', 16)\`. An explicit tag like \`!!int\` or \`!!float\` skips the resolver's regex entirely, so a sexagesimal value with an empty component (\`1::3\`) reaches the constructor directly with nothing checking it first.

Either path ends the same way: a plain \`ValueError\` escapes out of \`safe_load\`, which isn't really the intended contract (malformed YAML should raise a \`yaml.YAMLError\`, not whatever builtin exception happened to bubble up from the underlying conversion). \`construct_yaml_binary\` already wraps its own base64-decoding errors in \`ConstructorError\` for the same reason; this does the same for the numeric constructors rather than tightening the resolver regex, since that regex is public API a lot of code probably depends on for tag detection and I didn't want to risk changing what gets auto-tagged as an int/float.

Added a small test file covering the three cases from the issue plus a couple of adjacent ones (an all-underscore octal/binary body, and confirming ordinary values like \`0x1A\`, \`1_000\`, and sexagesimal floats still parse the same as before).